### PR TITLE
v2.1: config file + setup CLI, atomic writes, sort/archive, UI polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,66 @@
 # contexts-mcp
 
-A local MCP server (with optional web UI) for **persistent context folders** shared across Claude Code sessions. Each context is a folder; each context holds items as markdown, txt, json, yaml, yml, or csv. Markdown items carry YAML frontmatter (title, tags, timestamps); other kinds carry only filesystem metadata. Contexts themselves can carry metadata (title, description, free-form status, tags, links) — useful for both knowledge-base topics and unit-of-work folders.
+A local MCP server (with optional web UI) for **persistent context folders** shared across Claude Code sessions. Each context is a folder; each context holds items as markdown, txt, json, yaml, yml, csv, or sql. Markdown items carry YAML frontmatter (title, tags, timestamps); other kinds carry only filesystem metadata. Contexts themselves can carry metadata (title, description, free-form status, tags, links) — useful for both knowledge-base topics and unit-of-work folders.
 
 Storage is plain files on disk under a single data directory, so contexts are easy to inspect, back up, or sync with any tool you already use.
 
 ---
 
-## Install & build
+## One command you actually need to remember
+
+**`npm run setup`**
+
+That's it. It rebuilds `dist/`, prompts for data dir + UI port, and (on Windows) refreshes the Desktop shortcut. Safe to re-run any time — after moving the install, after changing your data dir, whenever something looks wrong.
+
+| Want to… | Command |
+|---|---|
+| Install, reconfigure, or recover | `npm run setup` |
+| Start the UI | `npm run ui` *or* `npx contexts-mcp-ui` |
+| Confirm things are wired up | `npm run sanity` |
+| See "what am I pointing at?" | open the UI → footer **About**, or call `context_diagnose` |
+
+## First-time setup
 
 ```bash
-git clone git@github.com:mupersega/contexts-mcp.git
+git clone https://github.com/mupersega/contexts-mcp.git
 cd contexts-mcp
 npm install
-npm run build
-```
-
-That produces `dist/index.js` (the MCP server) and `dist/web.js` (the web UI).
-
-## Register with Claude Code
-
-Point Claude Code at the built server. The simplest route is the `claude mcp add` CLI:
-
-```bash
+npm run setup
 claude mcp add contexts-mcp -- node /absolute/path/to/contexts-mcp/dist/index.js
 ```
 
-That writes an entry like this into your project's `.mcp.json` (or `~/.claude/mcp.json` for user scope):
+Restart Claude Code. Tools prefixed `mcp__contexts-mcp__` should now be available.
 
-```json
-{
-  "mcpServers": {
-    "contexts-mcp": {
-      "command": "node",
-      "args": ["/absolute/path/to/contexts-mcp/dist/index.js"]
-    }
-  }
-}
+`npm run setup` is interactive — it prompts for your data directory (defaulting to an OS-appropriate location) and UI port, then writes a shared config file. The MCP server and the web UI both read from that config, so they always agree on where data lives.
+
+> Contributors can swap the first command for `git@github.com:mupersega/contexts-mcp.git` (SSH). HTTPS is the default here because it works out of the box without a GitHub key.
+
+---
+
+## How it resolves configuration
+
+Config priority, highest first:
+
+1. `CONTEXTS_DATA_DIR` / `CONTEXTS_UI_PORT` in the environment
+2. The config file written by `npm run setup`:
+   - Windows: `%APPDATA%\contexts-mcp\config.json`
+   - macOS: `~/Library/Application Support/contexts-mcp/config.json`
+   - Linux: `${XDG_CONFIG_HOME:-~/.config}/contexts-mcp/config.json`
+3. Otherwise the server **refuses to start** with a clear message pointing you at `npm run setup`. There is no silent fallback to `./contexts-data` in the current working directory.
+
+Both the MCP server and the UI log the resolved data dir to stderr at startup:
+
+```
+[contexts-mcp] version:   2.1.0
+[contexts-mcp] data dir:  /Users/you/Library/Application Support/contexts-mcp/data (from config)
+[contexts-mcp] config:    /Users/you/Library/Application Support/contexts-mcp/config.json
 ```
 
-Restart Claude Code. You should see tools prefixed with `mcp__contexts-mcp__` available.
+To confirm at runtime, call `context_diagnose` or visit the UI and expand the **About** panel in the footer.
 
-## Environment variables
+### Pointing the MCP at a different data dir
 
-| Variable | Default | Notes |
-|---|---|---|
-| `CONTEXTS_DATA_DIR` | `./contexts-data` (relative to cwd) | Where contexts are stored. **Use an absolute path** so the location doesn't shift with whatever directory Claude Code launches from. |
-| `CONTEXTS_UI_PORT` | `3141` | Port for the optional web UI. |
-
-Pass env vars through in your MCP registration if you want a custom data dir:
+If you want a project-specific data dir, override via the `env` block in `.mcp.json`:
 
 ```json
 {
@@ -61,70 +74,86 @@ Pass env vars through in your MCP registration if you want a custom data dir:
 }
 ```
 
+The env var wins over the config file. The UI, however, reads only the config file and its own environment — keep them in sync, or run the UI in the same shell where you've set `CONTEXTS_DATA_DIR`.
+
+---
+
 ## Web UI (optional)
 
-A CRT/terminal-styled browser view over the same data:
+A CRT/terminal-styled browser view over the same data.
 
 ```bash
-npm run ui
-# then open http://localhost:3141
+npm run ui        # then open http://localhost:3141
 ```
 
-Stop it with the **Shutdown** button in the footer — it POSTs to `/shutdown` and the server exits cleanly, releasing the port.
+Once built and configured, you can also use the cross-platform launcher:
+
+```bash
+npx contexts-mcp-ui   # starts the UI if it isn't running, opens the browser
+```
+
+Stop the server with the **Shutdown** button in the footer — it POSTs to `/shutdown` and the process exits cleanly, releasing the port. **Shutdown performs zero writes to the data dir** — it is release-the-port only.
+
+Per-item actions on the UI:
+
+- **Copy** — copies the raw content. Hold Alt on markdown items to include the YAML frontmatter.
+- **Download** — streams the file verbatim with its original filename and correct `Content-Type`.
+- **Raw** — toggles a rendered/raw view (useful for eyeballing frontmatter before copying).
+- Context-level **Download .zip** from the context page.
 
 ### Windows convenience (optional)
 
-`scripts/install.ps1` creates a **Desktop** shortcut that launches the UI (via `scripts/contexts-ui.vbs`, which starts `node dist\web.js` hidden and opens the browser):
+`npm run setup` already offers to create/refresh the Desktop shortcut. If you want just the shortcut step without the config prompts (e.g. after moving the install), call `install.ps1` directly:
 
 ```powershell
-powershell -ExecutionPolicy Bypass -File scripts\install.ps1
+powershell -ExecutionPolicy Bypass -File scripts\install.ps1 -SkipSetup
 ```
 
-To also auto-start at Windows login, pass `-AutoStart`:
+Add `-AutoStart` (to either command) for an additional Startup-folder shortcut that auto-runs the UI at Windows login.
 
-```powershell
-powershell -ExecutionPolicy Bypass -File scripts\install.ps1 -AutoStart
-```
-
-To remove the shortcuts later (including the Startup-folder one):
+To remove the shortcuts later:
 
 ```powershell
 powershell -ExecutionPolicy Bypass -File scripts\uninstall.ps1
 ```
 
-The uninstall script only removes shortcuts. If a server is already running, use the footer **Shutdown** button (or `taskkill`) to stop it.
+---
 
 ## Data model — quick reference
 
 - **Context** = a folder inside your data dir. Name matches `^[a-zA-Z0-9_-]+$`.
-- **Item** = one file inside a context. Base name matches `^[a-zA-Z0-9][a-zA-Z0-9_-]*$`. Extension is one of `md`, `txt`, `json`, `yaml`, `yml`, `csv`.
+- **Item** = one file inside a context. Base name matches `^[a-zA-Z0-9][a-zA-Z0-9_-]*$`. Extension is one of `md`, `txt`, `json`, `yaml`, `yml`, `csv`, `sql`.
 - **Markdown items** carry YAML frontmatter with `title`, `tags`, `created`, `updated`.
-- **Non-markdown items** have only filesystem metadata. Want rich metadata on a JSON/CSV payload? Drop a companion `.md` in the same context.
-- **Context metadata** lives in an optional `_context.yaml` at the context root: `title`, `description`, `status`, `tags`, `links: [{label, url}]`, `created`, `updated`. Never exposed as an item.
+- **Non-markdown items** have only filesystem metadata. Want rich metadata on a JSON/CSV/SQL payload? Drop a companion `.md` in the same context.
+- **Context metadata** lives in an optional `_context.yaml` at the context root: `title`, `description`, `status`, `tags`, `links: [{label, url}]`, `created`, `updated`, `last_activity`. Never exposed as an item. `last_activity` is managed automatically — don't set it manually.
+- **Archival convention**: `status: 'archived'` makes a context invisible to default `list_contexts` / `search_contexts`. Pass `include_archived: true` (or toggle it in the UI) to see them.
+- **Data-dir version stamp**: `.contexts-mcp-version` at the data-dir root tracks the schema version. Future server versions can use this for migrations.
 
 ## MCP tools
 
-All 13 tools the server exposes:
+All tools the server exposes:
 
-- `list_contexts` — list all context folders; `include_metadata=true` also returns each context's title/description/status/tags/links.
+- `list_contexts` — list all contexts. `include_metadata=true` also returns title/description/status/tags/links/last_activity. `sort` accepts `name | recent_activity | created | updated` (default `name`). `include_archived=true` to include archived contexts.
 - `create_context` — create a new named context folder.
 - `delete_context` — delete a context and everything inside it (destructive).
 - `get_context` — read a context's metadata.
-- `update_context_metadata` — patch a context's metadata (only passed fields change).
+- `update_context_metadata` — patch a context's metadata (only passed fields change). Set `status: 'archived'` to archive.
 - `list_items` — list items in a context.
-- `get_item` — read an item's content (markdown returns frontmatter + body; others return raw text).
+- `get_item` — read an item's parsed content (markdown returns frontmatter + body; others return raw text).
+- `get_item_raw` — byte-for-byte content of an item on disk, including markdown frontmatter. Returns `{content, filename, contentType, extension, size}`.
 - `create_item` — create a new item; specify extension, optionally title/tags for markdown.
 - `update_item` — replace an item's content (and title/tags for markdown).
-- `append_to_item` — append to an existing md/txt/csv item. Errors on json/yaml/yml.
+- `append_to_item` — append to an existing md/txt/csv/sql item. Errors on json/yaml/yml.
 - `delete_item` — delete a single item (destructive).
-- `search_contexts` — full-text search across all items, with optional filters by context, per-item tags, context status, or context tags.
-- `context_migration_brief` — returns a markdown guide covering formats, naming rules, frontmatter shape, and a recommended workflow for importing existing notes into the server.
+- `search_contexts` — full-text search across all items, with optional filters by context, per-item tags, context status, or context tags. Archived contexts skipped unless `include_archived=true`.
+- `context_diagnose` — return `{dataDir, configPath, version, contextCount, archivedCount, itemCount, totalBytes, lastScanMs}`. Cheap to call. Confirms "what data dir is this process actually reading?" when things look wrong.
+- `context_migration_brief` — returns a markdown guide covering formats, naming rules, frontmatter shape, and a recommended workflow for importing existing notes.
 
 ---
 
 ## Automation: keep contexts updated without thinking about it
 
-You can invoke these tools manually any time, but the real win is letting Claude Code call them on your behalf. Two patterns, each good for something different:
+You can invoke these tools manually any time, but the real win is letting Claude Code call them on your behalf. See [`docs/claude-code-setup.md`](docs/claude-code-setup.md) for the exact `permissions.allow[]` block that preapproves the write tools so Claude (including sub-agents) doesn't hit a permission prompt on every call.
 
 ### Option A — a Skill (recommended default)
 
@@ -136,6 +165,7 @@ name: persist-to-contexts
 description: Save findings, patterns, decisions, or reusable knowledge to a persistent contexts-mcp context. Use whenever the conversation surfaces something the user might want to look up later — debugging solutions, API quirks, architectural decisions, domain knowledge.
 allowed-tools:
   - mcp__contexts-mcp__list_contexts
+  - mcp__contexts-mcp__search_contexts
   - mcp__contexts-mcp__create_context
   - mcp__contexts-mcp__create_item
   - mcp__contexts-mcp__append_to_item
@@ -145,18 +175,15 @@ allowed-tools:
 
 When something worth remembering surfaces in this conversation:
 
-1. Pick or create a context folder by topic (e.g. `golang-patterns`, `postgres-gotchas`, `project-auth-rewrite`). Use `list_contexts` to see what already exists.
-2. Pick a short item base name (no spaces, no special chars). Examples: `error-handling`, `uuid-collation-bug`, `decisions`.
-3. Append the finding as markdown via `append_to_item`, or `create_item` if the item doesn't exist yet. Prefix with a date if it's a dated note.
-
-Prefer appending to existing items over creating many near-duplicates — contexts work best as growing, dated logs.
+1. Call `list_contexts` with `sort: "recent_activity"` and `include_metadata: true` to see what's recent.
+2. Call `search_contexts` for a phrase — you may find an existing item to append to rather than duplicate.
+3. Otherwise, pick or create a context folder by topic and `create_item`.
+4. Prefer appending to existing items over creating many near-duplicates — contexts work best as growing, dated logs.
 ```
-
-Claude reads `description` to decide when to invoke the skill. Front-load it with the kinds of moments you want to trigger on. `allowed-tools` preapproves the MCP calls so there's no permission prompt mid-flow.
 
 ### Option B — a Stop hook (for deterministic end-of-turn reminders)
 
-If you'd rather have Claude _always_ reflect at the end of a turn, wire up a `Stop` hook in `.claude/settings.json` (project scope) or `~/.claude/settings.json` (user scope):
+If you'd rather have Claude _always_ reflect at the end of a turn, wire up a `Stop` hook in `.claude/settings.json` (project) or `~/.claude/settings.json` (user):
 
 ```json
 {
@@ -176,23 +203,21 @@ If you'd rather have Claude _always_ reflect at the end of a turn, wire up a `St
 }
 ```
 
-The echoed text becomes a system reminder in Claude's next turn, nudging it to save. See the [Claude Code hooks docs](https://docs.claude.com/en/docs/claude-code/hooks) for the full event list and JSON shapes.
-
-### Which to pick
-
-- **Skill** if "save this" is a judgment call — most knowledge capture.
-- **Hook** if you want a deterministic trigger — end of every turn, every tool call, session start, etc.
-
-They compose fine: use the hook as a reminder, let the skill do the actual capture.
+See the [Claude Code hooks docs](https://docs.claude.com/en/docs/claude-code/hooks) for the full event list and JSON shapes. Skill + hook compose fine — hook as reminder, skill for the capture.
 
 ---
 
 ## Development
 
 ```bash
-npm run watch   # tsc --watch
-npm run start   # node dist/index.js (stdio; for direct testing)
-npm run ui      # node dist/web.js (browser UI)
+npm run watch    # tsc --watch
+npm run start    # node dist/index.js (stdio; for direct testing)
+npm run ui       # node dist/web.js (browser UI)
+npm run setup    # reconfigure data dir / UI port
+npm run sanity   # invariant checks — ~1s, catches quiet wrongness
+npm run bench    # write-path benchmark — baselines createItem / list p50/p95/p99
 ```
+
+`scripts/sanity.js` and `scripts/bench.js` both run against a throwaway data dir under `$TMPDIR`. They don't touch your configured `dataDir`.
 
 Diagnostics go to stderr; stdout is reserved for the MCP JSON-RPC transport.

--- a/bin/contexts-mcp-ui.js
+++ b/bin/contexts-mcp-ui.js
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+// Cross-platform UI launcher. Starts the web server detached if it's not
+// already responding on the configured port, then opens the browser.
+//
+// Mirrors what scripts/contexts-ui.vbs does on Windows, but works anywhere
+// Node does — so the Desktop icon flow doesn't have to be Windows-only.
+
+import { spawn } from "child_process";
+import http from "http";
+import path from "path";
+import { fileURLToPath } from "url";
+import { loadConfig, MissingDataDirError } from "../dist/config.js";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "..");
+const webEntry = path.join(repoRoot, "dist", "web.js");
+
+function pingPort(port, timeoutMs = 400) {
+  return new Promise((resolve) => {
+    const req = http.get({ host: "127.0.0.1", port, path: "/", timeout: timeoutMs }, (res) => {
+      res.resume();
+      resolve(true);
+    });
+    req.on("error", () => resolve(false));
+    req.on("timeout", () => {
+      req.destroy();
+      resolve(false);
+    });
+  });
+}
+
+async function waitForPort(port, attempts = 20, intervalMs = 200) {
+  for (let i = 0; i < attempts; i++) {
+    if (await pingPort(port)) return true;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  return false;
+}
+
+function openBrowser(url) {
+  const platform = process.platform;
+  const cmd =
+    platform === "win32" ? "cmd" :
+    platform === "darwin" ? "open" :
+    "xdg-open";
+  const args = platform === "win32" ? ["/c", "start", "", url] : [url];
+  try {
+    spawn(cmd, args, { detached: true, stdio: "ignore" }).unref();
+  } catch (err) {
+    console.error(`Could not open browser: ${err.message}\nOpen ${url} manually.`);
+  }
+}
+
+async function main() {
+  let cfg;
+  try {
+    cfg = loadConfig();
+  } catch (err) {
+    if (err instanceof MissingDataDirError) {
+      console.error("No data dir configured. Run: contexts-mcp-setup (or: npm run setup).");
+      process.exit(1);
+    }
+    throw err;
+  }
+
+  const port = cfg.uiPort;
+  const url = `http://localhost:${port}`;
+
+  const running = await pingPort(port);
+  if (!running) {
+    const child = spawn(process.execPath, [webEntry], {
+      cwd: repoRoot,
+      detached: true,
+      stdio: "ignore",
+    });
+    child.unref();
+    const up = await waitForPort(port);
+    if (!up) {
+      console.error(`UI did not come up on :${port} within a few seconds.`);
+      process.exit(1);
+    }
+  }
+
+  openBrowser(url);
+}
+
+main().catch((err) => {
+  console.error("Launcher failed:", err);
+  process.exit(1);
+});

--- a/docs/claude-code-setup.md
+++ b/docs/claude-code-setup.md
@@ -1,0 +1,81 @@
+# Using contexts-mcp inside Claude Code
+
+This guide covers the two permission patterns that make contexts-mcp pleasant to use from Claude Code — especially for **sub-agents launched via the `Agent(...)` tool**, which inherit more restrictive default permissions than the main session and will hit a permission prompt on every write if you don't preapprove the tools.
+
+## Option A — preapprove the MCP tools in settings
+
+Add this block to `~/.claude/settings.json` (user scope — applies everywhere) or to `<project>/.claude/settings.json` (project scope):
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "mcp__contexts-mcp__list_contexts",
+      "mcp__contexts-mcp__get_context",
+      "mcp__contexts-mcp__get_item",
+      "mcp__contexts-mcp__get_item_raw",
+      "mcp__contexts-mcp__list_items",
+      "mcp__contexts-mcp__search_contexts",
+      "mcp__contexts-mcp__context_diagnose",
+      "mcp__contexts-mcp__context_migration_brief",
+      "mcp__contexts-mcp__create_context",
+      "mcp__contexts-mcp__create_item",
+      "mcp__contexts-mcp__update_item",
+      "mcp__contexts-mcp__append_to_item",
+      "mcp__contexts-mcp__update_context_metadata"
+    ]
+  }
+}
+```
+
+The `delete_context` and `delete_item` tools are deliberately omitted — those are destructive, worth a permission prompt every time.
+
+Reload Claude Code for the change to take effect.
+
+## Option B — a Skill with `allowed-tools`
+
+If you'd rather scope the preapproval to a specific workflow, use a Skill. Skill YAML supports `allowed-tools`, which preapproves the listed tools *only while the skill is running*. Create `~/.claude/skills/persist-to-contexts/SKILL.md`:
+
+```markdown
+---
+name: persist-to-contexts
+description: Save findings, patterns, decisions, or reusable knowledge to a persistent contexts-mcp context. Use whenever the conversation surfaces something worth looking up later — debugging solutions, API quirks, architectural decisions, domain knowledge.
+allowed-tools:
+  - mcp__contexts-mcp__list_contexts
+  - mcp__contexts-mcp__search_contexts
+  - mcp__contexts-mcp__create_context
+  - mcp__contexts-mcp__create_item
+  - mcp__contexts-mcp__append_to_item
+  - mcp__contexts-mcp__update_context_metadata
+---
+
+## How to save
+
+1. Call `list_contexts` with `sort: "recent_activity"` and `include_metadata: true` to see recent topics.
+2. Call `search_contexts` for a phrase that might already be logged.
+3. If the topic exists, prefer `append_to_item` over a new item.
+4. Otherwise: `create_context` (if it's a new topic) and `create_item`.
+5. Markdown is the right default for prose; use the other kinds only for structured payloads.
+```
+
+Skills are the right call when "save this" is a judgment call — Claude reads the `description` to decide when to invoke it.
+
+## Which to pick
+
+| You want… | Use |
+|---|---|
+| Preapproval everywhere, forever | Option A (settings.json) |
+| Preapproval scoped to a workflow | Option B (Skill) |
+| Both | Both — they compose |
+
+## Verifying it worked
+
+Start a fresh Claude Code session. Run:
+
+```
+/mcp
+```
+
+You should see `contexts-mcp` listed with a tool count. Then ask Claude to save something — e.g. `"save a quick note to contexts about X"` — and there should be no permission prompt on the write tools you preapproved.
+
+If you see prompts anyway, double-check that the tool names in `allow[]` match the Claude Code format exactly: `mcp__<server-name>__<tool-name>`.

--- a/install-and-pathing-improvements.md
+++ b/install-and-pathing-improvements.md
@@ -1,0 +1,268 @@
+---
+title: Install & dynamic-pathing improvements — notes from a rough first setup
+tags:
+  - install
+  - pathing
+  - ux
+  - dx
+  - observability
+  - migration
+created: '2026-04-15T02:46:41.065Z'
+updated: '2026-04-15T09:18:47.612Z'
+---
+Feedback captured during a bumpy migration from a ticket-based predecessor MCP to contexts-mcp on Windows. Ordered roughly by impact.
+
+## 1. The cwd-relative data dir default is the single biggest trap
+
+Default `CONTEXTS_DATA_DIR=./contexts-data` sounds harmless but explodes in practice. Claude Code launches the MCP from whatever its current working directory is, which on a developer box is usually inside a project repo. Result: on a fresh install with no env var set, context data lands *inside the user's project*. I ended up with 44 ticket folders inside `C:/projects/payadvantage/contexts-data/` before I realised what had happened.
+
+### Ideas
+- **Refuse to start without an explicit data dir.** If `CONTEXTS_DATA_DIR` is unset, error with a short "set CONTEXTS_DATA_DIR or pass `--data-dir`" message. No silent cwd default.
+- **Or**: default to a predictable OS-appropriate location — `%LOCALAPPDATA%/contexts-mcp/data` on Windows, `~/Library/Application Support/contexts-mcp` on macOS, `$XDG_DATA_HOME/contexts-mcp` on Linux. Never cwd.
+- **On startup, log the resolved absolute data dir to stderr** (the README already notes stderr is for diagnostics). That one-line "Using data dir: C:/foo/bar" would have saved an hour.
+
+## 2. Installer-created shortcuts hard-wire the install path
+
+`scripts/install.ps1` creates `%USERPROFILE%\Desktop\Contexts.lnk` and a Startup shortcut with `WorkingDirectory` and `Arguments` pointing at the install location (e.g. `C:/projects/contexts-mcp/`). If the user later moves the install — which I had to — those shortcuts silently break. No error, no hint, UI just doesn't come up at next login.
+
+### Ideas
+- **Ship an `uninstall.ps1` that updates (not just deletes) shortcuts** when it detects a reinstall at a different path.
+- **Have the shortcut target a stable entrypoint** — e.g. an npm global bin `contexts-mcp-ui` — instead of an absolute `wscript ...vbs` path. Then "moving the install" is just re-running install.
+- **Print the intended shortcut target paths at end of install** so the user can eyeball them.
+
+## 3. The vbs launcher ignores `CONTEXTS_DATA_DIR`
+
+`scripts/contexts-ui.vbs` sets `CurrentDirectory = projectDir` and runs `node dist\web.js`. If the user set `CONTEXTS_DATA_DIR` in their `.mcp.json` env block (because the README tells them to), the UI launched via the shortcut will *not* see that value — it only applies when Claude Code spawns the server. Result: the UI reads a completely different (empty) data dir. I lost a good chunk of time to this.
+
+### Ideas
+- **Resolve data dir via a config file** (e.g. `~/.contexts-mcp/config.json`) that *both* the MCP-launched server and the UI-launched server read. Env var can still win as an override, but the config file is the shared source of truth.
+- **Have the vbs read a `%USERPROFILE%\.contexts-mcp\env` file** and `SetEnv` before launching node.
+- **At minimum: document this very explicitly in the README**, ideally with a "UI and MCP must agree on data dir" box at the top of the Env Vars section.
+
+## 4. No "where am I pointing?" diagnostic
+
+When the UI silently showed empty folders (because the data had moved but the server was still pointing at old cwd-relative path), there was no easy way to answer "what data dir is this process actually reading?". I fell back to process listings and `lsof`-equivalents.
+
+### Ideas
+- **`GET /health` or `/diagnose` on the web server** returning `{ dataDir, contextCount, itemCount, version }`. Make it a small JSON blob shown in a collapsible "About" section of the UI footer.
+- **A `context_diagnose` MCP tool** that returns the same info. Cheap to add, huge for debugging — saves me asking "are we talking to the same instance you think we are?".
+- **Surface resolved dataDir in the UI chrome** — small monospace path somewhere unobtrusive. Confidence-building and debugging gold.
+
+## 5. Migration tooling: the brief is nice, a CLI would be better
+
+`context_migration_brief` is well written. But when I had 44 folders to import with markdown + attachments + computed titles + `_context.yaml` generation, I ended up writing ~150 lines of Node from scratch to parse YAML frontmatter, normalise filenames, generate metadata. The brief gave me the *rules* but not the *tool*.
+
+### Ideas
+- **`contexts-mcp import <dir>` CLI subcommand** that takes a directory of markdown+attachments and does sensible defaults: one context per subfolder, `<ticket>.md` becomes `overview.md`, other files become items with filename normalisation (`.` → `-`, unsupported ext → `txt`), derives title from H1 / first Summary paragraph, sets `_context.yaml` from any source frontmatter.
+- Even a **`--dry-run`** mode that prints "would create N contexts and M items, Y renames" would catch half the gotchas.
+- The filename regex (`/^[a-zA-Z0-9][a-zA-Z0-9_-]*$/`, no dots in base, fixed extension set) is aggressive — migrations from any system with "real" filenames will need normalisation. Ship that normaliser.
+
+## 6. External FS changes are silently destructive
+
+During my migration I moved the data folder with the server and the web UI still running. When I brought them back up, the folders existed but their contents were gone. I can't prove what happened but the symptom pattern (folders kept, files missing) suggests the still-running process cleaned up or rewrote on shutdown after losing track of its storage.
+
+### Ideas
+- **File watcher or inode-check on startup.** If the data dir has changed under the server's feet (moved/recreated), log it and refuse to auto-delete or re-sync anything.
+- **On graceful shutdown (the `/shutdown` POST), never write to the data dir.** Make shutdown purely release-the-port.
+- **Atomic writes with a `.tmp` sidecar** for any metadata file (`_context.yaml`) — current behaviour during a partial write would corrupt the yaml.
+
+## 7. Unsupported extensions force awkward renames
+
+Enum-restricting items to `md/txt/json/yaml/yml/csv` is reasonable for a text DB, but it made migrating a `.sql` file awkward — I stored it as `testing-queries-sql.txt` to preserve the type hint in the name. A CSV or SQL dump next to a context is a pretty natural use case.
+
+### Ideas
+- **Add `sql` to the enum** — it's just text.
+- **Or: allow a `raw` / `bin` kind** with arbitrary extension stored verbatim, no frontmatter, no indexing, just file-in-context. Docs can say "use `md` by default, only reach for `raw` when you need to attach an oddly-typed artefact".
+
+## 8. Permissions story for Claude Code sub-agents
+
+Not strictly a contexts-mcp issue, but adjacent: sub-agents launched via `Agent(...)` in Claude Code get *more restrictive* default permissions than the main session. The write MCP tools (`create_context`, `create_item`, `update_context_metadata`) were auto-denied in sub-agents even after being approved in the main session. Two sub-agents burned through their budget just discovering this.
+
+### Ideas
+- **A `docs/claude-code-setup.md` page** in the repo that lists the exact `permissions.allow[]` entries to add to `~/.claude/settings.json` for frictionless sub-agent usage. Example:
+  ```json
+  "permissions": { "allow": [
+    "mcp__contexts-mcp__create_context",
+    "mcp__contexts-mcp__create_item",
+    "mcp__contexts-mcp__update_context_metadata",
+    "mcp__contexts-mcp__append_to_item"
+  ]}
+  ```
+- **Skill YAML with `allowed-tools`** (the README already shows this for `persist-to-contexts`) — good pattern, worth flagging more loudly as "this is the easiest way to use the server from inside Claude".
+
+## 9. Cross-platform install convenience is Windows-only
+
+`install.ps1`, `contexts-ui.vbs`, desktop/startup shortcut creation — all Windows. A macOS/Linux developer picking up the tool gets `npm install && npm run build && npm run ui` and no convenience layer.
+
+### Ideas
+- **A tiny cross-platform wrapper**: ship `bin/contexts-mcp-ui` as a Node shebang script that does the "is it running on 3141? if not, start it; then open the browser" dance the vbs does. Works everywhere Node works.
+- **Optional LaunchAgent (macOS) + systemd user unit (Linux) templates** for auto-start parity with the Windows Startup shortcut.
+
+## 10. Small polish
+
+- **Single bundled `dist/` artifact** via esbuild / ncc. 105 npm packages in `node_modules` for a relatively small MCP is a lot to drag around, and matters if you ever want to distribute this as a standalone exe.
+- **Versioned data dir** — stamp a `.contexts-mcp-version` file at the root of the data dir on first write. Future server versions can do migrations or refuse to start against incompatible data.
+- **Make the `_context.yaml` generator strip noisy auto-managed fields** when re-serialising (the `created`/`updated` from source frontmatter got carried into `overview.md`'s preserved frontmatter and then a second set got added by the server — minor cosmetic).
+- **README "five-minute setup" section** up top: `npm i && build && setx CONTEXTS_DATA_DIR … && register with claude mcp add`. Right now the README is well-structured but the happy path is spread across several sections and easy to miss pieces of.
+
+## 11. Reference: what actually happened in this session
+
+For the maintainer's postmortem value:
+
+1. MCP server launched by Claude Code with cwd = `C:/projects/payadvantage` → data wrote to `./contexts-data` = inside the repo.
+2. `.mcp.json` initially had no `env` block, so no `CONTEXTS_DATA_DIR`.
+3. Moved data to `C:/contexts-data`, moved server to `C:/tools/contexts-mcp`, updated `.mcp.json` with `env: { CONTEXTS_DATA_DIR }`. Desktop + Startup shortcuts silently broken (still pointed at old install path).
+4. Shut down web UI via the `/shutdown` POST (worked well — nice touch).
+5. On next bring-up the context folders were present but empty — contents lost somewhere between the move and the shutdown, not fully diagnosed.
+6. Re-ran a custom migration script to repopulate.
+
+None of these steps are blocking — they're all navigable — but they cost real time, and a newcomer trying the tool cold could plausibly bounce off.
+
+
+
+
+## 12. Context ordering: "recently active" beats alphabetical
+
+`list_contexts` and (I'm assuming) the web UI both order contexts alphabetically. For a growing corpus that's actively worked on, alphabetical is the wrong default — the contexts you touched yesterday sink below `AGENTS-*` and `CHUNKER-V1V2` forever. You scan 40+ rows to find the one you wrote to this morning.
+
+### Ideas
+- **A `sort` parameter on `list_contexts`**: `name | recent_activity | created | updated`. `recent_activity` = max(mtime) across all items in the context (including `_context.yaml`). Default could stay `name` to avoid surprising existing callers, or flip to `recent_activity` if you're willing to make a breaking change — it's the answer a human almost always wants.
+- **Mirror the same control in the UI** with a small "Sort by: name ▾ / recent ▾ / status ▾" affordance in the header. Optional filter-by-status dropdown pairs naturally with it.
+- **Track `last_activity` in `_context.yaml`** as a derived field so callers don't have to stat every item on every list. Update it on any `create_item` / `update_item` / `append_to_item` / metadata write. Cheap, and makes the sort a single read per context.
+- **Bonus**: expose a `recent_activity` timestamp in the `list_contexts(include_metadata: true)` response even if you don't change the default sort, so clients can sort themselves.
+
+
+
+
+## 13. UI: no way to copy or download an item
+
+Once an item is in a context, the only way to get the raw content back out — verbatim, with original formatting — is to open the file on disk. From the web UI there's no "copy content" button, no "download as file", and no raw view. For markdown that's annoying; for a JSON attachment (a Postman collection, a test fixture) it's a genuine blocker — you're looking at rendered markdown or a preview, not the shippable file.
+
+### Ideas
+- **Per-item "Copy" button** (copies the raw text content — for md, the body *without* the YAML frontmatter unless you hold a modifier key; for non-md, the raw payload). One click, no permission prompts.
+- **Per-item "Download" button** that streams the file with its original filename and a correct `Content-Type` header (`text/markdown`, `application/json`, `text/csv`, etc.). No transformation.
+- **A "raw" view toggle** per item — show the plain text (with frontmatter for md) in a monospace block, not rendered. Useful for eyeballing exact content before copying.
+- **Context-level "Download all as .zip"** — for handing a whole topic's worth of notes + attachments to someone who doesn't have the MCP running. Cheap with something like `archiver` in Node; huge for sharing.
+- **On the MCP side** a matching `get_item_raw` that returns `{ content, filename, contentType }` would let any client (UI, CLI, other MCP) implement the same feature consistently.
+
+Small thing, but it's the difference between "contexts are where my stuff *lives*" and "contexts are where my stuff is *trapped*".
+
+
+
+
+## 14. Scale: load, lifecycle, and the no-pagination constraint
+
+Today I imported 44 contexts in one go — fine. But thinking forward: at 100, 500, 1000 contexts with accumulating items, what breaks first, and what's the plan to keep the UX sharp without resorting to pagination?
+
+### Where the load lives today
+- `list_contexts(include_metadata: true)` reads every `_context.yaml` — O(n) on every call.
+- `search_contexts` reads every text item in every context — O(total bytes) on every call.
+- `list_items` stats every file in a context — O(items-per-context).
+
+At 44 contexts all of this is imperceptible. At 1000 contexts with 5 items each, `include_metadata` is 1000 yaml reads per UI refresh, and search is scanning tens of MB every keystroke if it's live.
+
+### The constraint
+**Pagination is the wrong answer here and should be delayed as long as possible.** The whole point of this tool is "everything I know, at a glance". The moment you hide contexts behind "Load more", the hit rate on the tool drops because users can't scan-and-recognise. Pagination is the refuge of apps that gave up on curating their surface area.
+
+### Better levers to pull first
+
+- **Lifecycle / archival as the primary pressure valve.** A context's `status` is already free-form. Bless a convention: `archived` contexts are omitted from default `list_contexts` results unless `include_archived: true` is passed. Same for search. Now the "working set" stays small even if the archive grows unbounded. UI gets an "Archive" toggle in the metadata sidebar and an "Archived (147)" chip in the header.
+- **Auto-archive suggestions, not auto-archive itself.** On server startup (or on a timer), flag contexts whose `last_activity` is > N days old *and* `status == done` — surface a dismissable banner in the UI: "12 contexts haven't been touched in 90+ days. Archive them?". Never auto-archive without consent, but make it one click to sweep.
+- **A derived index cached at the data-dir root.** `_index.json` holding `{ name, title, status, tags, last_activity, item_count, total_size }` per context, rebuilt on any write. `list_contexts(include_metadata: true)` then reads one file instead of n. Invalidation is cheap because every write already goes through the server. Search can maintain its own token/bigram index in the same file if you want to get fancy.
+- **Search result streaming / progressive reveal.** If `search_contexts` must walk n contexts, stream results as contexts finish rather than buffering the whole response. The UI feels instant even when the full scan is slow.
+- **Let archival itself be cheap and reversible.** Archiving is just a status change — no move, no rename, no data hidden from the filesystem. One-key unarchive from the UI.
+- **Surface scale stats in the diagnose endpoint** (see section 4). `{ contextCount, archivedCount, itemCount, totalBytes, lastScanMs }` so you can actually see the trend and not guess when the pressure starts mattering.
+
+### What I'd explicitly *not* do
+
+- No pagination in `list_contexts`, `list_items`, or the UI grid for as long as possible. Archival + filter + index make this unnecessary until low thousands.
+- No automatic deletion. Ever. The tool's value depends on "I can trust it remembers".
+- No TTLs or stale-data expiry. Same reason.
+
+### Rule of thumb for when this actually starts hurting
+
+If `list_contexts(include_metadata: true)` crosses ~100ms or search crosses ~500ms in real usage, the index approach is overdue. Both are easy to measure with the diagnose endpoint. Until then, the current approach is fine and the archival knob is enough.
+
+
+
+
+## 15. Dark mode is too dark — eye strain after a short session
+
+Light mode is in a great spot now — readable, not too clinical, leave it alone. Dark mode is the opposite extreme: it's *very* black, with high-contrast text on a near-pure-black background, and it gets uncomfortable to read for more than a few minutes.
+
+### What's likely going on
+- Background is at or near `#000` instead of an off-black like `#0d1117` (GitHub) / `#1a1b26` (Tokyo Night) / `#1e1e2e` (Catppuccin Mocha).
+- Foreground text is probably at or near `#fff`, giving the maximum-possible contrast ratio. Sounds good on paper; in practice it sears the retina against pure black, especially for long-form reading.
+- The CRT/terminal aesthetic likely leans into the high-contrast look intentionally — but reading 5KB of markdown is not the same as reading a status line.
+
+### Suggested pass
+- **Lift the background.** Try `#16181d` to `#1c1f26` range. Anything below `#10` is too far.
+- **Drop the foreground.** Body text around `#c9d1d9` / `#cdd6f4` rather than `#ffffff`. Keep `#fff` for headings or active selection only.
+- **Aim for a contrast ratio of ~10–13:1**, not ~21:1. Still well above WCAG AA (4.5:1) for body text, but kinder on a long read.
+- **Soften accents.** Whatever the link/highlight colour is, desaturate it ~20% — pure-saturation greens/cyans on near-black are the other half of the eye-strain story.
+- **Keep the CRT/terminal vibe** in chrome (footer, status bar, button styles) but treat the *content area* — the markdown body where people actually read — as a long-form reading surface. Two slightly different background tones is fine and signals "you can rest your eyes here".
+- Optional: a **"low-contrast" sub-mode** for dark, gated by a small toggle. Same palette, just compressed range. Cheap to add and people self-select.
+
+Light mode passed the "I want to keep using this" test; dark mode hasn't yet. A short pass on the two background/foreground values would close most of the gap.
+
+
+
+
+## 16. README clone command assumes SSH
+
+The README's install section starts with:
+
+```bash
+git clone git@github.com:mupersega/contexts-mcp.git
+```
+
+That's the SSH URL, which only works for users who've set up an SSH key on their GitHub account. A fresh developer following the README will hit `Permission denied (publickey)` and bounce. I had to substitute the HTTPS URL to get past it.
+
+### Fix
+Change the README to default to HTTPS:
+
+```bash
+git clone https://github.com/mupersega/contexts-mcp.git
+```
+
+HTTPS works out-of-the-box for everyone (including read-only clones without credentials) and is the standard "getting started" default on GitHub itself. SSH can be mentioned as an alternative one-liner for contributors, but it shouldn't be the first command in the install flow.
+
+
+
+
+## 17. Tests — probably not a full suite, but a perf smoke test is earning its keep
+
+Today there's no test harness. For a tool this size a full unit-test suite is overkill and would outweigh the value, and I think the maintainer's instinct to skip it is correct. What I *would* add is a single benchmark/smoke script because write performance is visibly slower than I'd expect.
+
+### The observation
+`create_item` / `update_item` / `create_context` felt sluggish even for small payloads in my 44-ticket migration. Fast enough that I didn't debug it, slow enough that I noticed. When I later bypassed the MCP and wrote directly to the filesystem (via a one-off Node script), the same 44 contexts + 27 attachments landed almost instantly. The gap suggests the server is doing more per write than the payload size warrants.
+
+### Likely culprits (without having read the code)
+- **Re-reading and re-serialising `_context.yaml` on every item write** to bump a timestamp. If so, a single `create_context + 6 items + metadata update` = 7+ reads and 7+ writes of that yaml.
+- **YAML parse/serialise round-trip on every markdown frontmatter edit** — cheap individually, expensive in aggregate.
+- **Per-write `fsync`** (or the Windows equivalent). Safe for durability, brutal for throughput.
+- **No in-process cache** of parsed `_context.yaml` / item frontmatter, so the same file is re-parsed per call.
+
+### What to add
+
+**A `scripts/bench.js` one-shot** that does something like:
+
+```js
+// Create N contexts each with K markdown items, measure each stage.
+// Print: createContext p50/p95/p99, createItem p50/p95/p99, updateContextMetadata p50/p95/p99.
+// Run against a throwaway data dir.
+```
+
+This is maybe 60 lines of code and gives you a repeatable number. Any future optimisation (batched writes, metadata caching, skipping redundant writes) can be measured against it. Baseline now would probably show the write path is the problem, not search or list.
+
+**A handful of invariant tests disguised as sanity checks** — no framework, just `node scripts/sanity.js`. Things like:
+
+- Create a context, add an item, delete the item, create an item with the *same* base name — it should succeed (no stale handle / leftover index).
+- Write a context with tags `['a', 'b']`, update with tags `['c']` — final state is `['c']`, not the union.
+- After `/shutdown` POST, re-read the data dir — every `_context.yaml` should parse and match what was written. (This would have caught the empty-folders-after-shutdown behaviour I hit earlier in the session.)
+
+These are the kind of "if this breaks, the tool is quietly wrong" checks that are cheap to write and catch the long-tail bugs that actual users stumble into.
+
+### What *not* to add
+
+Don't stand up Jest/Vitest/etc. for this. Framework overhead + config + watchers + a `test/` directory convention — the tool's whole vibe is "minimal, understandable, hack-on-it-in-an-afternoon". Keep it to plain Node scripts under `scripts/`. If they grow past ~300 LOC total, then reconsider.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,25 +1,28 @@
 {
   "name": "contexts-mcp",
-  "version": "1.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "contexts-mcp",
-      "version": "1.0.0",
+      "version": "2.1.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.0",
+        "archiver": "^7.0.1",
         "express": "^5.1.0",
         "gray-matter": "^4.0.3",
         "js-yaml": "^4.1.0",
         "marked": "^15.0.0",
-        "zod": "^3.23.0",
-        "zod-to-json-schema": "^3.23.5"
+        "zod": "^3.23.0"
       },
       "bin": {
-        "contexts-mcp": "dist/index.js"
+        "contexts-mcp": "dist/index.js",
+        "contexts-mcp-setup": "dist/setup.js",
+        "contexts-mcp-ui": "bin/contexts-mcp-ui.js"
       },
       "devDependencies": {
+        "@types/archiver": "^6.0.3",
         "@types/express": "^5",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^22",
@@ -36,6 +39,23 @@
       },
       "peerDependencies": {
         "hono": "^4"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
@@ -76,6 +96,26 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@types/archiver": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-6.0.4.tgz",
+      "integrity": "sha512-ULdQpARQ3sz9WH4nb98mJDYA0ft2A8C4f4fovvUcFwINa1cgGjY36JCAYuP5YypRq4mco1lJp1/7jEMS2oR0Hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/readdir-glob": "*"
       }
     },
     "node_modules/@types/body-parser": {
@@ -162,6 +202,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/readdir-glob": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/readdir-glob/-/readdir-glob-1.1.5.tgz",
+      "integrity": "sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
@@ -181,6 +231,18 @@
       "dependencies": {
         "@types/http-errors": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
       }
     },
     "node_modules/accepts": {
@@ -229,11 +291,209 @@
         }
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/archiver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
+      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.2",
+        "async": "^3.2.4",
+        "buffer-crc32": "^1.0.0",
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^6.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
+      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^10.0.0",
+        "graceful-fs": "^4.2.0",
+        "is-stream": "^2.0.1",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.17.15",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
+    "node_modules/b4a": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.7.tgz",
+      "integrity": "sha512-G4Gr1UsGeEy2qtDTZwL7JFLo2wapUarz7iTMcYcMFdS89AIQuBoyjgXZz0Utv7uHs3xA9LckhVbeBi8lEQrC+w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.0.tgz",
+      "integrity": "sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.0.tgz",
+      "integrity": "sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "2.2.2",
@@ -257,6 +517,48 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/bytes": {
@@ -295,6 +597,40 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/compress-commons": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
+      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^6.0.0",
+        "is-stream": "^2.0.1",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/content-disposition": {
@@ -337,6 +673,12 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -352,6 +694,31 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
+      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/cross-spawn": {
@@ -408,10 +775,22 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -479,6 +858,33 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
       }
     },
     "node_modules/eventsource": {
@@ -582,6 +988,12 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -617,6 +1029,22 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/forwarded": {
@@ -683,6 +1111,27 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -694,6 +1143,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
     },
     "node_modules/gray-matter": {
       "version": "4.0.3",
@@ -802,6 +1257,26 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -835,10 +1310,37 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -846,6 +1348,21 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
     },
     "node_modules/jose": {
       "version": "6.2.2",
@@ -888,6 +1405,60 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/marked": {
       "version": "15.0.12",
@@ -956,6 +1527,30 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -969,6 +1564,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-assign": {
@@ -1013,6 +1617,12 @@
         "wrappy": "1"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1029,6 +1639,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-to-regexp": {
@@ -1049,6 +1675,21 @@
       "engines": {
         "node": ">=16.20.0"
       }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -1102,6 +1743,43 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -1126,6 +1804,26 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -1290,6 +1988,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -1305,6 +2015,122 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamx": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-bom-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
@@ -1312,6 +2138,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
+      "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/toidentifier": {
@@ -1367,6 +2223,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -1391,11 +2253,116 @@
         "node": ">= 8"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/zip-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
+      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.0",
+        "compress-commons": "^6.0.2",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/zod": {
       "version": "3.25.76",

--- a/package.json
+++ b/package.json
@@ -1,20 +1,26 @@
 {
   "name": "contexts-mcp",
-  "version": "2.0.0",
-  "description": "Local MCP server (with optional web UI) for persistent context folders shared across Claude Code sessions. Stores items as md, txt, json, yaml, yml, or csv.",
+  "version": "2.1.0",
+  "description": "Local MCP server (with optional web UI) for persistent context folders shared across Claude Code sessions. Stores items as md, txt, json, yaml, yml, csv, or sql.",
   "type": "module",
   "bin": {
-    "contexts-mcp": "dist/index.js"
+    "contexts-mcp": "dist/index.js",
+    "contexts-mcp-setup": "dist/setup.js",
+    "contexts-mcp-ui": "bin/contexts-mcp-ui.js"
   },
   "scripts": {
     "build": "tsc",
     "watch": "tsc --watch",
     "start": "node dist/index.js",
     "ui": "node dist/web.js",
+    "setup": "tsc && node dist/setup.js",
+    "bench": "node scripts/bench.js",
+    "sanity": "node scripts/sanity.js",
     "install:shortcut": "powershell -ExecutionPolicy Bypass -File scripts/install.ps1"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.17.0",
+    "archiver": "^7.0.1",
     "express": "^5.1.0",
     "gray-matter": "^4.0.3",
     "js-yaml": "^4.1.0",
@@ -22,6 +28,7 @@
     "zod": "^3.23.0"
   },
   "devDependencies": {
+    "@types/archiver": "^6.0.3",
     "@types/express": "^5",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^22",

--- a/scripts/bench.js
+++ b/scripts/bench.js
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+// scripts/bench.js — write-path throughput smoke test.
+//
+// Creates a throwaway data dir next to the repo, spawns N contexts × K items
+// with the storage module's normal code path, and prints p50/p95/p99 for the
+// operations that matter for interactive feel: createContext, createItem,
+// updateContextMetadata, and list_contexts(include_metadata=true).
+//
+// Usage: node scripts/bench.js
+// Override via env: BENCH_N=50 BENCH_K=20 node scripts/bench.js
+
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { fileURLToPath, pathToFileURL } from "url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "..");
+const tmpRoot = path.join(os.tmpdir(), `contexts-mcp-bench-${process.pid}-${Date.now()}`);
+
+process.env.CONTEXTS_DATA_DIR = tmpRoot;
+process.env.CONTEXTS_UI_PORT = "0"; // unused, but keep loadConfig happy if it ever reads
+
+const storage = await import(pathToFileURL(path.join(repoRoot, "dist", "storage.js")).href);
+
+const N = parseInt(process.env.BENCH_N || "20", 10);
+const K = parseInt(process.env.BENCH_K || "10", 10);
+
+function percentile(sorted, p) {
+  if (sorted.length === 0) return 0;
+  const idx = Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length));
+  return sorted[idx];
+}
+
+async function time(fn) {
+  const t0 = process.hrtime.bigint();
+  await fn();
+  return Number(process.hrtime.bigint() - t0) / 1e6;
+}
+
+function report(label, samples) {
+  samples.sort((a, b) => a - b);
+  const p50 = percentile(samples, 50);
+  const p95 = percentile(samples, 95);
+  const p99 = percentile(samples, 99);
+  const total = samples.reduce((s, v) => s + v, 0);
+  console.log(
+    `${label.padEnd(32)} n=${String(samples.length).padStart(4)}   p50=${p50.toFixed(2).padStart(7)}ms   p95=${p95.toFixed(2).padStart(7)}ms   p99=${p99.toFixed(2).padStart(7)}ms   total=${total.toFixed(1)}ms`,
+  );
+}
+
+async function run() {
+  console.log(`contexts-mcp bench`);
+  console.log(`  data dir: ${tmpRoot}`);
+  console.log(`  N=${N} contexts × K=${K} items per context (${N * K} items total)`);
+  console.log("");
+
+  await storage.ensureDataDir();
+
+  const createContextSamples = [];
+  const createItemSamples = [];
+  const updateMetaSamples = [];
+
+  for (let i = 0; i < N; i++) {
+    const name = `bench-${String(i).padStart(4, "0")}`;
+    createContextSamples.push(await time(() => storage.createContext(name)));
+
+    for (let k = 0; k < K; k++) {
+      const base = `item-${String(k).padStart(3, "0")}`;
+      const content = `# ${base}\n\nSome body content line 1.\nSome body content line 2.\n`;
+      createItemSamples.push(
+        await time(() => storage.createItem(name, base, "md", { title: base, content }))
+      );
+    }
+
+    updateMetaSamples.push(
+      await time(() =>
+        storage.updateContextMetadata(name, {
+          title: `Bench ${i}`,
+          description: "benchmark context",
+          status: i % 7 === 0 ? "archived" : "active",
+          tags: ["bench"],
+        })
+      )
+    );
+  }
+
+  const listSamples = [];
+  for (let t = 0; t < 5; t++) {
+    listSamples.push(await time(() => storage.listContexts({ includeMetadata: true })));
+  }
+  const listRecentSamples = [];
+  for (let t = 0; t < 5; t++) {
+    listRecentSamples.push(
+      await time(() =>
+        storage.listContexts({ includeMetadata: true, sort: "recent_activity" })
+      )
+    );
+  }
+  const diagSamples = [];
+  for (let t = 0; t < 3; t++) {
+    diagSamples.push(await time(() => storage.getDiagnostics()));
+  }
+
+  console.log("");
+  report("createContext",                 createContextSamples);
+  report("createItem (md)",               createItemSamples);
+  report("updateContextMetadata",         updateMetaSamples);
+  report("list_contexts(metadata)",       listSamples);
+  report("list_contexts(recent_activity)", listRecentSamples);
+  report("getDiagnostics",                diagSamples);
+}
+
+async function cleanup() {
+  try {
+    await fs.promises.rm(tmpRoot, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+}
+
+run()
+  .then(cleanup)
+  .catch(async (err) => {
+    await cleanup();
+    console.error("bench failed:", err);
+    process.exit(1);
+  });

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,10 +1,12 @@
 # Contexts UI shortcut installer
 # Default: creates a Desktop shortcut only (click-to-launch).
 # With -AutoStart: also creates a Startup-folder shortcut (auto-runs at login).
-# Re-running is idempotent — existing shortcuts are overwritten.
+# With -SkipSetup: does NOT run the interactive setup step.
+# Re-running is idempotent - existing shortcuts are overwritten.
 
 param(
-    [switch]$AutoStart
+    [switch]$AutoStart,
+    [switch]$SkipSetup
 )
 
 $ErrorActionPreference = 'Stop'
@@ -12,10 +14,36 @@ $ErrorActionPreference = 'Stop'
 $scriptDir  = Split-Path -Parent $MyInvocation.MyCommand.Path
 $projectDir = Split-Path -Parent $scriptDir
 $vbsPath    = Join-Path $scriptDir 'contexts-ui.vbs'
+$setupJs    = Join-Path $projectDir 'dist\setup.js'
+$distIndex  = Join-Path $projectDir 'dist\index.js'
 
 if (-not (Test-Path $vbsPath)) {
     Write-Error "Launcher not found at $vbsPath"
     exit 1
+}
+
+if (-not (Test-Path $distIndex)) {
+    Write-Host "dist/ not found - running npm run build first..."
+    Push-Location $projectDir
+    try { npm run build | Out-Host } finally { Pop-Location }
+}
+
+if (-not $SkipSetup) {
+    if (-not (Test-Path $setupJs)) {
+        Write-Error "Setup entrypoint not found at $setupJs - did the build succeed?"
+        exit 1
+    }
+    Write-Host ''
+    Write-Host '=== Interactive setup ==='
+    Write-Host 'Configuring data directory and UI port.'
+    Write-Host 'Press Enter to accept the suggested defaults.'
+    Write-Host ''
+    # node dist/setup.js runs in foreground so the user can see the prompts.
+    & node $setupJs
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Setup failed (exit $LASTEXITCODE). Re-run manually: node dist\setup.js"
+        exit $LASTEXITCODE
+    }
 }
 
 $desktopLnk = Join-Path ([Environment]::GetFolderPath('Desktop')) 'Contexts.lnk'
@@ -28,10 +56,11 @@ function New-ContextsShortcut {
     $sc.TargetPath       = Join-Path $env:WINDIR 'System32\wscript.exe'
     $sc.Arguments        = '"' + $vbsPath + '"'
     $sc.WorkingDirectory = $projectDir
-    $sc.Description      = 'Contexts — launch UI and open browser'
+    $sc.Description      = 'Contexts - launch UI and open browser'
     $sc.WindowStyle      = 7
     $sc.Save()
     Write-Host "Created: $LnkPath"
+    Write-Host "  targets: $vbsPath"
 }
 
 New-ContextsShortcut -LnkPath $desktopLnk
@@ -42,6 +71,8 @@ if ($AutoStart) {
 
 Write-Host ''
 Write-Host 'Contexts is now installed.'
+Write-Host "  Install path: $projectDir"
+Write-Host "  Launcher:     $vbsPath"
 Write-Host '  Desktop icon: double-click Contexts on your desktop'
 if ($AutoStart) {
     Write-Host '  Auto-start:   runs at next Windows login'
@@ -52,3 +83,5 @@ if ($AutoStart) {
     Write-Host 'Auto-start at login is NOT enabled. To enable it, re-run with:'
     Write-Host '  powershell -ExecutionPolicy Bypass -File scripts\install.ps1 -AutoStart'
 }
+Write-Host ''
+Write-Host 'If you move this install to a new path later, re-run install.ps1 from the new location to rewrite the shortcuts.'

--- a/scripts/sanity.js
+++ b/scripts/sanity.js
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+// scripts/sanity.js — the invariant checks that catch "quietly wrong" bugs.
+//
+// No framework. Runs against a throwaway data dir. Exits non-zero on failure.
+
+import fs from "fs";
+import path from "path";
+import os from "os";
+import yaml from "js-yaml";
+import { fileURLToPath, pathToFileURL } from "url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "..");
+const tmpRoot = path.join(os.tmpdir(), `contexts-mcp-sanity-${process.pid}-${Date.now()}`);
+
+process.env.CONTEXTS_DATA_DIR = tmpRoot;
+
+const storage = await import(pathToFileURL(path.join(repoRoot, "dist", "storage.js")).href);
+
+let failed = 0;
+async function check(label, fn) {
+  try {
+    await fn();
+    console.log(`  ok  ${label}`);
+  } catch (err) {
+    failed += 1;
+    console.error(`  FAIL  ${label}\n        ${err instanceof Error ? err.message : err}`);
+  }
+}
+
+function assertEq(actual, expected, msg) {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(`${msg}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+async function run() {
+  console.log("contexts-mcp sanity");
+  console.log(`  data dir: ${tmpRoot}`);
+  console.log("");
+  await storage.ensureDataDir();
+
+  await check("re-creating a deleted item succeeds (no stale index)", async () => {
+    await storage.createContext("reuse");
+    await storage.createItem("reuse", "thing", "md", { title: "first", content: "a" });
+    await storage.deleteItem("reuse", "thing");
+    await storage.createItem("reuse", "thing", "md", { title: "second", content: "b" });
+    const items = await storage.listItems("reuse");
+    assertEq(items.length, 1, "item count after recreate");
+    assertEq(items[0].title, "second", "title after recreate");
+  });
+
+  await check("tag update replaces, not unions", async () => {
+    await storage.createContext("tags");
+    await storage.updateContextMetadata("tags", { tags: ["a", "b"] });
+    await storage.updateContextMetadata("tags", { tags: ["c"] });
+    const meta = await storage.getContextMetadata("tags");
+    assertEq(meta.tags, ["c"], "tag replacement");
+  });
+
+  await check("_context.yaml survives a round-trip of mutations", async () => {
+    await storage.createContext("yaml-rt");
+    await storage.updateContextMetadata("yaml-rt", {
+      title: "Round Trip",
+      description: "yaml integrity test",
+      status: "active",
+      tags: ["alpha", "beta"],
+      links: [{ label: "spec", url: "https://example.com" }],
+    });
+    await storage.createItem("yaml-rt", "note", "md", { title: "n", content: "body" });
+    const raw = fs.readFileSync(path.join(tmpRoot, "yaml-rt", "_context.yaml"), "utf-8");
+    const parsed = yaml.load(raw);
+    if (!parsed || typeof parsed !== "object") throw new Error("yaml failed to parse");
+    const p = parsed;
+    assertEq(p.title, "Round Trip", "title preserved");
+    assertEq(p.tags, ["alpha", "beta"], "tags preserved");
+    if (typeof p.last_activity !== "string" || p.last_activity.length === 0) {
+      throw new Error("last_activity not set after item write");
+    }
+  });
+
+  await check("archived contexts filtered from default list", async () => {
+    await storage.createContext("visible");
+    await storage.createContext("hidden");
+    await storage.updateContextMetadata("hidden", { status: "archived" });
+    const defaultList = await storage.listContexts({ includeMetadata: true });
+    const names = defaultList.map((c) => c.name);
+    if (names.includes("hidden")) throw new Error("archived context leaked into default list");
+    if (!names.includes("visible")) throw new Error("visible context missing");
+    const full = await storage.listContexts({ includeMetadata: true, includeArchived: true });
+    const fullNames = full.map((c) => c.name);
+    if (!fullNames.includes("hidden")) throw new Error("archived context missing from include_archived=true");
+  });
+
+  await check("sort=recent_activity puts most-recently-touched first", async () => {
+    await storage.createContext("older");
+    await storage.createContext("newer");
+    await storage.createItem("older", "a", "md", { content: "old" });
+    await new Promise((r) => setTimeout(r, 25));
+    await storage.createItem("newer", "a", "md", { content: "new" });
+    const list = await storage.listContexts({
+      includeMetadata: true,
+      sort: "recent_activity",
+    });
+    // "newer" should precede "older".
+    const idxNewer = list.findIndex((c) => c.name === "newer");
+    const idxOlder = list.findIndex((c) => c.name === "older");
+    if (idxNewer === -1 || idxOlder === -1) throw new Error("contexts missing from list");
+    if (idxNewer > idxOlder) {
+      throw new Error(`recent_activity sort: newer(${idxNewer}) should precede older(${idxOlder})`);
+    }
+  });
+
+  await check("getItemRaw preserves frontmatter on md", async () => {
+    await storage.createContext("raw");
+    await storage.createItem("raw", "note", "md", { title: "T", content: "body here" });
+    const raw = await storage.getItemRaw("raw", "note");
+    if (!raw.content.startsWith("---")) throw new Error("raw md should lead with frontmatter");
+    if (!raw.content.includes("body here")) throw new Error("raw md should contain body");
+    assertEq(raw.filename, "note.md", "filename");
+  });
+
+  await check("sql extension accepted", async () => {
+    await storage.createContext("sqlctx");
+    await storage.createItem("sqlctx", "query", "sql", {
+      content: "SELECT 1;\n",
+    });
+    const raw = await storage.getItemRaw("sqlctx", "query");
+    assertEq(raw.extension, "sql", "ext");
+    assertEq(raw.contentType, "application/sql; charset=utf-8", "mime");
+  });
+
+  console.log("");
+  if (failed > 0) {
+    console.error(`${failed} check(s) failed`);
+    process.exit(1);
+  }
+  console.log("All checks passed.");
+}
+
+async function cleanup() {
+  try {
+    await fs.promises.rm(tmpRoot, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+}
+
+run()
+  .then(cleanup)
+  .catch(async (err) => {
+    await cleanup();
+    console.error("sanity failed:", err);
+    process.exit(1);
+  });

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -1,6 +1,6 @@
 # Contexts UI shortcut uninstaller
 # Removes the Desktop and Startup shortcuts created by install.ps1.
-# Does NOT stop a running server — use the Shutdown button in the UI
+# Does NOT stop a running server - use the Shutdown button in the UI
 # (or close the hidden wscript/node process manually) for that.
 
 $ErrorActionPreference = 'Stop'
@@ -22,5 +22,5 @@ Remove-ContextsShortcut -LnkPath $desktopLnk -Label 'Desktop'
 Remove-ContextsShortcut -LnkPath $startupLnk -Label 'Startup'
 
 Write-Host ''
-Write-Host 'Uninstall complete. A running server (if any) is still alive —'
+Write-Host 'Uninstall complete. A running server (if any) is still alive -'
 Write-Host 'open http://localhost:3141 and click Shutdown in the footer to stop it.'

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,155 @@
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { fileURLToPath } from "url";
+
+// Shared runtime config. One source of truth that the MCP server, the web UI,
+// and the interactive setup CLI all read from — so the launcher shortcut and
+// the .mcp.json-launched server can't disagree about which data dir they're
+// pointing at.
+
+export interface ContextsConfig {
+  dataDir: string;
+  uiPort: number;
+  version: string;
+}
+
+export interface ResolvedConfig extends ContextsConfig {
+  configPath: string;
+  source: {
+    dataDir: "env" | "config";
+    uiPort: "env" | "config" | "default";
+  };
+}
+
+export const CONFIG_SCHEMA_VERSION = "1";
+export const DEFAULT_UI_PORT = 3141;
+
+export class MissingDataDirError extends Error {
+  constructor() {
+    super(
+      "No data dir configured.\n" +
+        "\n" +
+        "  Run: npm run setup   (or: contexts-mcp setup)\n" +
+        "\n" +
+        "Or set CONTEXTS_DATA_DIR in the environment (e.g. the 'env' block of .mcp.json).",
+    );
+    this.name = "MissingDataDirError";
+  }
+}
+
+export function configPath(): string {
+  const home = os.homedir();
+  if (process.platform === "win32") {
+    const appData = process.env.APPDATA || path.join(home, "AppData", "Roaming");
+    return path.join(appData, "contexts-mcp", "config.json");
+  }
+  if (process.platform === "darwin") {
+    return path.join(home, "Library", "Application Support", "contexts-mcp", "config.json");
+  }
+  const xdg = process.env.XDG_CONFIG_HOME || path.join(home, ".config");
+  return path.join(xdg, "contexts-mcp", "config.json");
+}
+
+export function defaultDataDir(): string {
+  const home = os.homedir();
+  if (process.platform === "win32") {
+    const local = process.env.LOCALAPPDATA || path.join(home, "AppData", "Local");
+    return path.join(local, "contexts-mcp", "data");
+  }
+  if (process.platform === "darwin") {
+    return path.join(home, "Library", "Application Support", "contexts-mcp", "data");
+  }
+  const xdg = process.env.XDG_DATA_HOME || path.join(home, ".local", "share");
+  return path.join(xdg, "contexts-mcp");
+}
+
+function readConfigFile(): Partial<ContextsConfig> | null {
+  const p = configPath();
+  try {
+    const raw = fs.readFileSync(p, "utf-8");
+    const parsed = JSON.parse(raw) as Partial<ContextsConfig>;
+    if (!parsed || typeof parsed !== "object") return null;
+    return parsed;
+  } catch (err: unknown) {
+    if (err && typeof err === "object" && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw err;
+  }
+}
+
+let _cached: ResolvedConfig | null = null;
+
+export function loadConfig(): ResolvedConfig {
+  if (_cached) return _cached;
+
+  const cfg = readConfigFile();
+  const envData = process.env.CONTEXTS_DATA_DIR?.trim() || "";
+  const envPort = process.env.CONTEXTS_UI_PORT?.trim() || "";
+
+  let dataDir = "";
+  let dataDirSource: "env" | "config" = "config";
+  if (envData) {
+    dataDir = path.resolve(envData);
+    dataDirSource = "env";
+  } else if (cfg && typeof cfg.dataDir === "string" && cfg.dataDir.trim().length > 0) {
+    dataDir = path.resolve(cfg.dataDir);
+    dataDirSource = "config";
+  } else {
+    throw new MissingDataDirError();
+  }
+
+  let uiPort = DEFAULT_UI_PORT;
+  let uiPortSource: "env" | "config" | "default" = "default";
+  if (envPort) {
+    const n = parseInt(envPort, 10);
+    if (Number.isFinite(n) && n > 0) {
+      uiPort = n;
+      uiPortSource = "env";
+    }
+  } else if (cfg && typeof cfg.uiPort === "number" && cfg.uiPort > 0) {
+    uiPort = cfg.uiPort;
+    uiPortSource = "config";
+  }
+
+  _cached = {
+    dataDir,
+    uiPort,
+    version: CONFIG_SCHEMA_VERSION,
+    configPath: configPath(),
+    source: { dataDir: dataDirSource, uiPort: uiPortSource },
+  };
+  return _cached;
+}
+
+export function writeConfig(patch: Partial<ContextsConfig>): ContextsConfig {
+  const existing = readConfigFile() || {};
+  const merged: ContextsConfig = {
+    dataDir: patch.dataDir ?? (typeof existing.dataDir === "string" ? existing.dataDir : ""),
+    uiPort: patch.uiPort ?? (typeof existing.uiPort === "number" ? existing.uiPort : DEFAULT_UI_PORT),
+    version: CONFIG_SCHEMA_VERSION,
+  };
+  const p = configPath();
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+  _cached = null;
+  return merged;
+}
+
+export function resetConfigCache(): void {
+  _cached = null;
+}
+
+export function packageVersion(): string {
+  try {
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    // dist/config.js → dist/ → repo root
+    const pkg = path.resolve(here, "..", "package.json");
+    const raw = fs.readFileSync(pkg, "utf-8");
+    const parsed = JSON.parse(raw) as { version?: string };
+    return parsed.version || "unknown";
+  } catch {
+    return "unknown";
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,28 +10,32 @@ import {
   UpdateContextMetadataArgsSchema,
   ListItemsArgsSchema,
   GetItemArgsSchema,
+  GetItemRawArgsSchema,
   CreateItemArgsSchema,
   UpdateItemArgsSchema,
   AppendToItemArgsSchema,
   DeleteItemArgsSchema,
   SearchContextsArgsSchema,
+  ContextDiagnoseArgsSchema,
   ContextMigrationBriefArgsSchema,
 } from "./types.js";
 import * as storage from "./storage.js";
 import { searchContexts } from "./search.js";
+import { loadConfig, MissingDataDirError, packageVersion } from "./config.js";
 
 const server = new McpServer(
-  { name: "contexts-mcp", version: "2.0.0" },
+  { name: "contexts-mcp", version: packageVersion() },
   {
     capabilities: { tools: {} },
     instructions: [
-      "Persistent context folders for Claude Code sessions. A context is a folder holding items in any text format: md (default), txt, json, yaml, yml, csv. Markdown items carry frontmatter (title, tags, timestamps); other kinds have only filesystem metadata. Contexts themselves can carry optional metadata (title, description, free-form status, tags, links) — good for both knowledge-base topics and unit-of-work folders.",
+      "Persistent context folders for Claude Code sessions. A context is a folder holding items in any text format: md (default), txt, json, yaml, yml, csv, sql. Markdown items carry frontmatter (title, tags, timestamps); other kinds have only filesystem metadata. Contexts themselves can carry optional metadata (title, description, free-form status, tags, links) — good for both knowledge-base topics and unit-of-work folders.",
       "",
       "How to use this server:",
       "- When the user asks about a topic that may already be logged, call search_contexts first before answering from scratch.",
       "- When capturing a new finding, prefer append_to_item onto an existing topical context over creating a new one — contexts work best as growing logs.",
-      "- When exploring what's saved, call list_contexts with include_metadata=true so titles/status/tags are visible in one shot.",
-      "- Markdown is the right default for notes and prose. Only use json/yaml/csv when the payload is structurally meaningful (and note that append_to_item is disabled for those kinds — use update_item to replace).",
+      "- When exploring what's saved, call list_contexts with include_metadata=true so titles/status/tags are visible in one shot. Pass sort='recent_activity' when you want the recently-touched contexts first.",
+      "- Contexts with status='archived' are filtered out of list/search by default — pass include_archived=true to include them.",
+      "- Markdown is the right default for notes and prose. Only use json/yaml/csv/sql when the payload is structurally meaningful (and note that append_to_item is disabled for json/yaml/yml — use update_item to replace).",
     ].join("\n"),
   }
 );
@@ -42,7 +46,7 @@ const json = (value: unknown) => text(JSON.stringify(value, null, 2));
 const MIGRATION_BRIEF = `# Migrating existing markdown into contexts-mcp
 
 ## What this system is
-A **context** is a folder. An **item** is a single file inside that folder. Items can be: \`md\` (default), \`txt\`, \`json\`, \`yaml\`, \`yml\`, or \`csv\`. Contexts are flat — no subfolders of items. A context may also carry its own metadata in a reserved \`_context.yaml\` file (never exposed as an item).
+A **context** is a folder. An **item** is a single file inside that folder. Items can be: \`md\` (default), \`txt\`, \`json\`, \`yaml\`, \`yml\`, \`csv\`, or \`sql\`. Contexts are flat — no subfolders of items. A context may also carry its own metadata in a reserved \`_context.yaml\` file (never exposed as an item).
 
 ## Naming rules
 - **Context name**: \`/^[a-zA-Z0-9_-]+$/\` — letters, digits, hyphens, underscores. Examples: \`auth-rewrite\`, \`postgres_notes\`, \`2026-q2-planning\`.
@@ -65,7 +69,7 @@ body goes here
 \`title\` and \`tags\` are yours to set; \`created\`/\`updated\` are managed automatically. If your source markdown already has frontmatter with other fields, they'll be preserved but only the four above are surfaced in listings and search.
 
 ## Non-markdown items
-\`txt\`, \`json\`, \`yaml\`, \`yml\`, \`csv\` have **no frontmatter** — only filesystem metadata (name, size, ctime/mtime). If you want rich metadata on a structured payload, drop a companion \`.md\` next to it in the same context.
+\`txt\`, \`json\`, \`yaml\`, \`yml\`, \`csv\`, \`sql\` have **no frontmatter** — only filesystem metadata (name, size, ctime/mtime). If you want rich metadata on a structured payload, drop a companion \`.md\` next to it in the same context.
 
 ## \`_context.yaml\` (context-level metadata)
 Optional per-context metadata. All fields optional:
@@ -80,6 +84,8 @@ links:
     url: https://...
 \`\`\`
 
+\`status: archived\` is special: archived contexts are filtered out of default \`list_contexts\`/\`search_contexts\` results (opt in with \`include_archived: true\`). The server also tracks \`last_activity\` automatically — don't set it manually.
+
 ## Recommended migration workflow
 1. **Survey first.** Call \`list_contexts\` with \`include_metadata: true\` to see what contexts already exist. Avoid creating parallel contexts for the same topic.
 2. **Search before writing.** Before importing a file, call \`search_contexts\` on a key phrase — you may find an existing item to **append to** rather than duplicate.
@@ -91,7 +97,7 @@ links:
 ## Gotchas
 - \`append_to_item\` is **disabled** for \`json\`/\`yaml\`/\`yml\` — silently corrupting structured data is worse than erroring. Use \`update_item\` to replace the full payload.
 - When two items share a base name across different extensions (\`notes.md\` and \`notes.txt\`), pass \`extension\` to disambiguate; otherwise \`md\` wins.
-- Storage path is \`contexts-data/\` relative to the server, or \`$CONTEXTS_DATA_DIR\` if set. Migrating? Point that env var at your target before starting.
+- Storage path resolution: the server reads from \`~/.config/contexts-mcp/config.json\` (or the OS-appropriate equivalent), written by \`contexts-mcp setup\`. \`CONTEXTS_DATA_DIR\` in the environment overrides the config file.
 - File renames to fit the regex should happen in a preprocessing pass — the server rejects invalid names at the Zod boundary.
 
 ## Suggested tool sequence for a batch import
@@ -102,11 +108,15 @@ server.registerTool(
   "list_contexts",
   {
     description:
-      "List all context folders. Pass include_metadata=true to also return each context's title, description, status, tags, and links (slower, since it reads metadata for every context — but use it when you want a map of what topics exist before deciding where to write).",
+      "List all context folders. Pass include_metadata=true to also return each context's title/description/status/tags/links/last_activity. Pass sort='recent_activity' (or 'created' / 'updated') to order by time (most-recent first) instead of the default alphabetical. Archived contexts (status='archived') are filtered out unless include_archived=true.",
     inputSchema: ListContextsArgsSchema.shape,
   },
   async (args) => {
-    const summaries = await storage.listContexts(args.include_metadata);
+    const summaries = await storage.listContexts({
+      includeMetadata: args.include_metadata,
+      sort: args.sort,
+      includeArchived: args.include_archived,
+    });
     return json(args.include_metadata ? summaries : summaries.map((s) => s.name));
   }
 );
@@ -141,7 +151,7 @@ server.registerTool(
   "get_context",
   {
     description:
-      "Read a context's metadata: title, description, status, tags, and links. Returns empty defaults for contexts that have no metadata set yet.",
+      "Read a context's metadata: title, description, status, tags, links, and last_activity. Returns empty defaults for contexts that have no metadata set yet.",
     inputSchema: GetContextArgsSchema.shape,
   },
   async (args) => {
@@ -154,7 +164,7 @@ server.registerTool(
   "update_context_metadata",
   {
     description:
-      "Set or update a context's metadata. Only the fields you pass are changed; everything else is preserved. Use this to track unit-of-work state (status, links to tickets/PRs) or to give any context a human-readable title and description.",
+      "Set or update a context's metadata. Only the fields you pass are changed; everything else is preserved. Use this to track unit-of-work state (status, links to tickets/PRs) or to give any context a human-readable title and description. Set status='archived' to archive a context — it'll be hidden from default list/search until you either clear the status or pass include_archived=true.",
     inputSchema: UpdateContextMetadataArgsSchema.shape,
   },
   async (args) => {
@@ -168,7 +178,7 @@ server.registerTool(
   "list_items",
   {
     description:
-      "List all items in a context folder. Items may be markdown, txt, json, yaml, yml, or csv. Markdown items carry title/tags from YAML frontmatter; other kinds have only filesystem metadata.",
+      "List all items in a context folder. Items may be markdown, txt, json, yaml, yml, csv, or sql. Markdown items carry title/tags from YAML frontmatter; other kinds have only filesystem metadata.",
     inputSchema: ListItemsArgsSchema.shape,
   },
   async (args) => {
@@ -208,10 +218,23 @@ server.registerTool(
 );
 
 server.registerTool(
+  "get_item_raw",
+  {
+    description:
+      "Read an item's raw, byte-for-byte content as stored on disk — including YAML frontmatter for markdown. Returns {content, filename, contentType, extension, size}. Use this when you want the original file verbatim (e.g. to hand it to another tool) rather than the parsed structure get_item returns.",
+    inputSchema: GetItemRawArgsSchema.shape,
+  },
+  async (args) => {
+    const raw = await storage.getItemRaw(args.context, args.item, args.extension);
+    return json(raw);
+  }
+);
+
+server.registerTool(
   "create_item",
   {
     description:
-      "Create a new item in a context. Extension defaults to 'md' — pass one of (md, txt, json, yaml, yml, csv) to override. For markdown, also pass title and tags — they go into the YAML frontmatter. For other kinds, just pass content.",
+      "Create a new item in a context. Extension defaults to 'md' — pass one of (md, txt, json, yaml, yml, csv, sql) to override. For markdown, also pass title and tags — they go into the YAML frontmatter. For other kinds, just pass content.",
     inputSchema: CreateItemArgsSchema.shape,
   },
   async (args) => {
@@ -246,7 +269,7 @@ server.registerTool(
   "append_to_item",
   {
     description:
-      "Append content to an existing item. Supported for markdown, txt, and csv. Errors for structured-data kinds (json/yaml/yml) — use update_item for those.",
+      "Append content to an existing item. Supported for markdown, txt, csv, and sql. Errors for structured-data kinds (json/yaml/yml) — use update_item for those.",
     inputSchema: AppendToItemArgsSchema.shape,
   },
   async (args) => {
@@ -269,6 +292,19 @@ server.registerTool(
 );
 
 server.registerTool(
+  "context_diagnose",
+  {
+    description:
+      "Return server-side diagnostics: resolved data dir, config path, version, counts (contexts, archived contexts, items), total bytes on disk, and scan wall-clock. Cheap to call. Use this to confirm 'what data dir is this process actually reading?' when debugging, or to check whether an archival sweep would meaningfully reduce the working set.",
+    inputSchema: ContextDiagnoseArgsSchema.shape,
+  },
+  async () => {
+    const diag = await storage.getDiagnostics();
+    return json(diag);
+  }
+);
+
+server.registerTool(
   "context_migration_brief",
   {
     description:
@@ -282,7 +318,7 @@ server.registerTool(
   "search_contexts",
   {
     description:
-      "Full-text search across all text items in all contexts. Pass just 'query' for a broad search; all filters are optional. Narrow with 'context' (one folder), 'tags' (per-item markdown tags), or 'context_status' / 'context_tags' (context-level metadata).",
+      "Full-text search across all text items in all contexts. Pass just 'query' for a broad search; all filters are optional. Narrow with 'context' (one folder), 'tags' (per-item markdown tags), or 'context_status' / 'context_tags' (context-level metadata). Archived contexts are skipped unless include_archived=true.",
     inputSchema: SearchContextsArgsSchema.shape,
   },
   async (args) => {
@@ -291,19 +327,35 @@ server.registerTool(
       tagFilter: args.tags,
       contextStatus: args.context_status,
       contextTagFilter: args.context_tags,
+      includeArchived: args.include_archived,
     });
     return json(results);
   }
 );
 
 async function main() {
-  await storage.ensureDataDir();
+  try {
+    const cfg = loadConfig();
+    console.error(`[contexts-mcp] version:   ${packageVersion()}`);
+    console.error(`[contexts-mcp] data dir:  ${cfg.dataDir} (from ${cfg.source.dataDir})`);
+    console.error(`[contexts-mcp] config:    ${cfg.configPath}`);
+    await storage.ensureDataDir();
+  } catch (err) {
+    if (err instanceof MissingDataDirError) {
+      console.error("[contexts-mcp] startup failed — no data dir configured.");
+      console.error("");
+      console.error(err.message);
+      process.exit(1);
+    }
+    throw err;
+  }
+
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error("Contexts MCP Server running on stdio");
+  console.error("[contexts-mcp] MCP server running on stdio");
 }
 
 main().catch((error) => {
-  console.error("Fatal error:", error);
+  console.error("[contexts-mcp] Fatal:", error);
   process.exit(1);
 });

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,14 +1,8 @@
 import fs from "fs/promises";
 import path from "path";
 import matter from "gray-matter";
-import yaml from "js-yaml";
-import {
-  CONTEXT_META_FILENAME,
-  ContextMetadata,
-  ITEM_EXTENSIONS,
-  ITEM_NAME_REGEX,
-  ItemExtension,
-} from "./types.js";
+import { ContextMetadata, ItemExtension } from "./types.js";
+import { getContextMetadata, splitItemFilename } from "./storage.js";
 
 export interface SearchResult {
   context: string;
@@ -24,52 +18,9 @@ export interface SearchOptions {
   tagFilter?: string[];
   contextStatus?: string;
   contextTagFilter?: string[];
-}
-
-function splitItemFilename(filename: string): { base: string; ext: ItemExtension } | null {
-  if (filename === CONTEXT_META_FILENAME) return null;
-  const dotIdx = filename.lastIndexOf(".");
-  if (dotIdx <= 0) return null;
-  const base = filename.slice(0, dotIdx);
-  const ext = filename.slice(dotIdx + 1);
-  if (!(ITEM_EXTENSIONS as readonly string[]).includes(ext)) return null;
-  if (!ITEM_NAME_REGEX.test(base)) return null;
-  return { base, ext: ext as ItemExtension };
-}
-
-async function readContextMetadata(
-  dataDir: string,
-  ctx: string
-): Promise<ContextMetadata | null> {
-  const metaPath = path.join(dataDir, ctx, CONTEXT_META_FILENAME);
-  try {
-    const raw = await fs.readFile(metaPath, "utf-8");
-    const parsed = yaml.load(raw);
-    if (!parsed || typeof parsed !== "object") return null;
-    const r = parsed as Record<string, unknown>;
-    return {
-      title: typeof r.title === "string" ? r.title : undefined,
-      description: typeof r.description === "string" ? r.description : undefined,
-      status: typeof r.status === "string" ? r.status : undefined,
-      tags: Array.isArray(r.tags)
-        ? r.tags.filter((t): t is string => typeof t === "string")
-        : [],
-      links: Array.isArray(r.links)
-        ? (r.links as unknown[]).flatMap((l) =>
-            l &&
-            typeof l === "object" &&
-            typeof (l as { label?: unknown }).label === "string" &&
-            typeof (l as { url?: unknown }).url === "string"
-              ? [{ label: (l as { label: string }).label, url: (l as { url: string }).url }]
-              : []
-          )
-        : [],
-      created: typeof r.created === "string" ? r.created : "",
-      updated: typeof r.updated === "string" ? r.updated : "",
-    };
-  } catch {
-    return null;
-  }
+  // Default behavior is to skip contexts whose metadata.status === 'archived'.
+  // Callers opt in to include them.
+  includeArchived?: boolean;
 }
 
 export async function searchContexts(
@@ -90,15 +41,23 @@ export async function searchContexts(
 
   const filterByStatus = opts.contextStatus !== undefined;
   const filterByContextTags = opts.contextTagFilter && opts.contextTagFilter.length > 0;
+  const includeArchived = opts.includeArchived === true;
   const contextStatusLower = opts.contextStatus?.toLowerCase();
   const contextTagsLower = opts.contextTagFilter?.map((t) => t.toLowerCase());
+
+  const needsMeta = filterByStatus || filterByContextTags || !includeArchived;
 
   for (const ctx of contexts) {
     const ctxPath = path.join(dataDir, ctx);
 
-    // Context-level metadata filters.
-    if (filterByStatus || filterByContextTags) {
-      const meta = await readContextMetadata(dataDir, ctx);
+    if (needsMeta) {
+      let meta: ContextMetadata | null = null;
+      try {
+        meta = await getContextMetadata(ctx);
+      } catch {
+        meta = null;
+      }
+      if (!includeArchived && meta && meta.status === "archived") continue;
       if (filterByStatus) {
         if (!meta || !meta.status || meta.status.toLowerCase() !== contextStatusLower) {
           continue;
@@ -144,10 +103,8 @@ export async function searchContexts(
         }
 
         itemTitle = meta.title || parsed.base;
-        // Preserve historical behaviour: title + tags + body are all searchable.
         fullText = [itemTitle, itemTags.join(" "), fm.content].join("\n");
       } else {
-        // Non-md items have no tags — they can't match a per-item tag filter.
         if (opts.tagFilter && opts.tagFilter.length > 0) continue;
         itemTitle = parsed.base;
         itemTags = [];

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+import fs from "fs";
+import path from "path";
+import readline from "readline";
+import { spawnSync } from "child_process";
+import { fileURLToPath } from "url";
+import {
+  CONFIG_SCHEMA_VERSION,
+  DEFAULT_UI_PORT,
+  configPath,
+  defaultDataDir,
+  packageVersion,
+  writeConfig,
+} from "./config.js";
+
+// Read current config without going through loadConfig() — loadConfig throws
+// if neither env nor file is set, but setup needs to inspect partial state.
+function readRawConfig(): { dataDir?: string; uiPort?: number } {
+  try {
+    const raw = fs.readFileSync(configPath(), "utf-8");
+    const parsed = JSON.parse(raw);
+    return {
+      dataDir: typeof parsed.dataDir === "string" ? parsed.dataDir : undefined,
+      uiPort: typeof parsed.uiPort === "number" ? parsed.uiPort : undefined,
+    };
+  } catch {
+    return {};
+  }
+}
+
+async function prompt(rl: readline.Interface, question: string): Promise<string> {
+  return new Promise((resolve) => rl.question(question, (answer) => resolve(answer)));
+}
+
+async function main(): Promise<void> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const existing = readRawConfig();
+    const envDataDir = process.env.CONTEXTS_DATA_DIR?.trim();
+
+    console.log("");
+    console.log(`contexts-mcp setup  (v${packageVersion()})`);
+    console.log("");
+    console.log(`Config file: ${configPath()}`);
+    if (existing.dataDir || existing.uiPort !== undefined) {
+      console.log("");
+      console.log("Current config:");
+      if (existing.dataDir) console.log(`  dataDir: ${existing.dataDir}`);
+      if (existing.uiPort !== undefined) console.log(`  uiPort:  ${existing.uiPort}`);
+    }
+    if (envDataDir) {
+      console.log("");
+      console.log(`Note: CONTEXTS_DATA_DIR is set in this environment (${envDataDir}).`);
+      console.log("      Env var wins at runtime — the config file is only used when it's unset.");
+    }
+    console.log("");
+
+    // Data dir
+    const suggestedDataDir = existing.dataDir || defaultDataDir();
+    const dataDirAnswer = (
+      await prompt(rl, `Data directory [${suggestedDataDir}]: `)
+    ).trim();
+    const dataDir = path.resolve(dataDirAnswer || suggestedDataDir);
+
+    // UI port
+    const suggestedPort =
+      existing.uiPort !== undefined ? existing.uiPort : DEFAULT_UI_PORT;
+    const portAnswer = (await prompt(rl, `UI port [${suggestedPort}]: `)).trim();
+    const parsedPort = portAnswer ? parseInt(portAnswer, 10) : suggestedPort;
+    if (!Number.isFinite(parsedPort) || parsedPort <= 0 || parsedPort > 65535) {
+      console.error(`Invalid port: ${portAnswer}`);
+      process.exit(1);
+    }
+
+    fs.mkdirSync(dataDir, { recursive: true });
+    const written = writeConfig({ dataDir, uiPort: parsedPort });
+
+    console.log("");
+    console.log("Wrote config:");
+    console.log(`  ${configPath()}`);
+    console.log("");
+    console.log(`  dataDir: ${written.dataDir}`);
+    console.log(`  uiPort:  ${written.uiPort}`);
+    console.log(`  schema:  v${CONFIG_SCHEMA_VERSION}`);
+    console.log("");
+
+    // Platform-specific: offer to (re)install the Windows Desktop shortcut.
+    // This makes `npm run setup` the single command that rewires everything
+    // after a repo move, instead of a separate install.ps1 step.
+    if (process.platform === "win32") {
+      const shortcutAnswer = (
+        await prompt(rl, "Create/refresh Desktop shortcut for the UI? [Y/n] ")
+      ).trim().toLowerCase();
+      if (shortcutAnswer === "" || shortcutAnswer.startsWith("y")) {
+        const installPs1 = path.resolve(
+          path.dirname(fileURLToPath(import.meta.url)),
+          "..",
+          "scripts",
+          "install.ps1",
+        );
+        if (fs.existsSync(installPs1)) {
+          const result = spawnSync(
+            "powershell",
+            ["-ExecutionPolicy", "Bypass", "-File", installPs1, "-SkipSetup"],
+            { stdio: "inherit" },
+          );
+          if (result.status !== 0) {
+            console.error("Shortcut install returned non-zero — skipping.");
+          }
+        } else {
+          console.error(`Shortcut installer not found at ${installPs1}`);
+        }
+        console.log("");
+      }
+    } else {
+      console.log("Launch the UI any time with:  npx contexts-mcp-ui");
+      console.log("");
+    }
+
+    console.log("Next steps:");
+    console.log("  1. Register the MCP server with Claude Code:");
+    console.log(`       claude mcp add contexts-mcp -- node ${repoEntry()}`);
+    console.log("  2. Start the web UI (optional):");
+    console.log("       npm run ui     # then open http://localhost:" + written.uiPort);
+    console.log("");
+    console.log("Re-run this any time with:  npm run setup");
+    console.log("");
+  } finally {
+    rl.close();
+  }
+}
+
+function repoEntry(): string {
+  // dist/setup.js → dist/index.js in the same folder.
+  try {
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    return path.resolve(here, "index.js");
+  } catch {
+    return "dist/index.js";
+  }
+}
+
+main().catch((err) => {
+  console.error("Setup failed:", err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -2,6 +2,7 @@ import fs from "fs/promises";
 import path from "path";
 import matter from "gray-matter";
 import yaml from "js-yaml";
+import { loadConfig, packageVersion } from "./config.js";
 import {
   CONTEXT_META_FILENAME,
   CONTEXT_NAME_REGEX,
@@ -16,12 +17,42 @@ import {
   ItemInfo,
 } from "./types.js";
 
-const DATA_DIR =
-  process.env.CONTEXTS_DATA_DIR ||
-  path.join(process.cwd(), "contexts-data");
+// Lazy + memoized — avoids throwing MissingDataDirError at module load time so
+// unit tests and the setup CLI can import storage without a config present.
+let _cachedDataDir: string | null = null;
+function dataDir(): string {
+  if (_cachedDataDir) return _cachedDataDir;
+  _cachedDataDir = loadConfig().dataDir;
+  return _cachedDataDir;
+}
 
 export function getDataDir(): string {
-  return DATA_DIR;
+  return dataDir();
+}
+
+// Test / setup CLI hook — storage queries loadConfig() once, so if the config
+// file is rewritten after startup we need a way to bust the cache.
+export function resetDataDirCache(): void {
+  _cachedDataDir = null;
+}
+
+export const VERSION_STAMP_FILENAME = ".contexts-mcp-version";
+
+// --- Atomic write ---
+
+// tmp+rename guards against partial writes corrupting _context.yaml or an item
+// file if the process is killed mid-write. On POSIX rename is atomic; on NTFS
+// it's atomic within the same volume, which is the case here since tmp sits
+// next to the target.
+async function writeFileAtomic(filePath: string, content: string): Promise<void> {
+  const tmp = `${filePath}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  try {
+    await fs.writeFile(tmp, content, "utf-8");
+    await fs.rename(tmp, filePath);
+  } catch (err) {
+    await fs.rm(tmp, { force: true }).catch(() => {});
+    throw err;
+  }
 }
 
 // --- Path safety ---
@@ -40,7 +71,7 @@ function assertWithin(base: string, resolved: string, label: string): void {
 }
 
 function resolveContextPath(contextName: string): string {
-  const baseResolved = path.resolve(DATA_DIR);
+  const baseResolved = path.resolve(dataDir());
   const resolved = path.resolve(baseResolved, contextName);
   assertWithin(baseResolved, resolved, "context name");
   return resolved;
@@ -78,6 +109,8 @@ interface ParsedItemFilename {
 // Returns null for unsupported files and for the reserved _context.yaml.
 function splitItemFilename(filename: string): ParsedItemFilename | null {
   if (filename === CONTEXT_META_FILENAME) return null;
+  if (filename === VERSION_STAMP_FILENAME) return null;
+  if (filename.startsWith(".")) return null;
   const dotIdx = filename.lastIndexOf(".");
   if (dotIdx <= 0) return null;
   const base = filename.slice(0, dotIdx);
@@ -87,10 +120,47 @@ function splitItemFilename(filename: string): ParsedItemFilename | null {
   return { base, ext };
 }
 
+export function contentTypeFor(ext: ItemExtension): string {
+  switch (ext) {
+    case "md":
+      return "text/markdown; charset=utf-8";
+    case "json":
+      return "application/json; charset=utf-8";
+    case "yaml":
+    case "yml":
+      return "application/yaml; charset=utf-8";
+    case "csv":
+      return "text/csv; charset=utf-8";
+    case "sql":
+      return "application/sql; charset=utf-8";
+    case "txt":
+    default:
+      return "text/plain; charset=utf-8";
+  }
+}
+
 // --- Init ---
 
 export async function ensureDataDir(): Promise<void> {
-  await fs.mkdir(DATA_DIR, { recursive: true });
+  const dd = dataDir();
+  await fs.mkdir(dd, { recursive: true });
+
+  // Stamp the data dir with the server version on first write. Future versions
+  // can read this to decide whether to migrate or refuse to start. Today we
+  // just ensure the stamp exists — no migration logic yet.
+  const stampPath = path.join(dd, VERSION_STAMP_FILENAME);
+  try {
+    const existing = await fs.readFile(stampPath, "utf-8");
+    if (!existing.trim()) {
+      await writeFileAtomic(stampPath, `${packageVersion()}\n`);
+    }
+  } catch (err: unknown) {
+    if (err && typeof err === "object" && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
+      await writeFileAtomic(stampPath, `${packageVersion()}\n`);
+    } else {
+      throw err;
+    }
+  }
 }
 
 // --- Context metadata ---
@@ -128,6 +198,7 @@ function normalizeContextMetadata(raw: unknown): ContextMetadata {
   }
   if (typeof r.created === "string") meta.created = r.created;
   if (typeof r.updated === "string") meta.updated = r.updated;
+  if (typeof r.last_activity === "string") meta.last_activity = r.last_activity;
 
   return meta;
 }
@@ -156,12 +227,10 @@ async function writeContextMetadata(
   meta: ContextMetadata
 ): Promise<void> {
   const metaPath = resolveContextMetaPath(name);
-  // Make sure the context directory exists — fail loudly if not.
   await fs.access(resolveContextPath(name)).catch(() => {
     throw new Error(`Context '${name}' not found`);
   });
 
-  // Consistent key order when writing.
   const ordered: Record<string, unknown> = {};
   if (meta.title !== undefined) ordered.title = meta.title;
   if (meta.description !== undefined) ordered.description = meta.description;
@@ -170,21 +239,21 @@ async function writeContextMetadata(
   ordered.links = meta.links;
   if (meta.created) ordered.created = meta.created;
   if (meta.updated) ordered.updated = meta.updated;
+  if (meta.last_activity) ordered.last_activity = meta.last_activity;
 
   const out = yaml.dump(ordered, { sortKeys: false, lineWidth: 100, noRefs: true });
-  await fs.writeFile(metaPath, out, "utf-8");
+  await writeFileAtomic(metaPath, out);
 }
 
 export async function updateContextMetadata(
   name: string,
-  patch: Partial<Omit<ContextMetadata, "created" | "updated">>
+  patch: Partial<Omit<ContextMetadata, "created" | "updated" | "last_activity">>
 ): Promise<ContextMetadata> {
   const existing = await getContextMetadata(name);
   const now = new Date().toISOString();
 
   const merged: ContextMetadata = {
     ...existing,
-    // Only patch keys that were explicitly provided.
     ...(patch.title !== undefined ? { title: patch.title } : {}),
     ...(patch.description !== undefined ? { description: patch.description } : {}),
     ...(patch.status !== undefined ? { status: patch.status } : {}),
@@ -192,33 +261,96 @@ export async function updateContextMetadata(
     ...(patch.links !== undefined ? { links: patch.links } : {}),
     created: existing.created || now,
     updated: now,
+    last_activity: now,
   };
 
   await writeContextMetadata(name, merged);
   return merged;
 }
 
+// Bump last_activity on any item mutation. Idempotent against missing
+// _context.yaml — creates a minimal metadata file on first touch.
+async function touchContext(name: string): Promise<void> {
+  const existing = await getContextMetadata(name);
+  const now = new Date().toISOString();
+  const merged: ContextMetadata = {
+    ...existing,
+    created: existing.created || now,
+    updated: existing.updated || now,
+    last_activity: now,
+  };
+  await writeContextMetadata(name, merged);
+}
+
 // --- Context operations ---
 
-export async function listContexts(
-  includeMetadata = false
-): Promise<ContextSummary[]> {
-  await ensureDataDir();
-  const entries = await fs.readdir(DATA_DIR, { withFileTypes: true });
-  const names = entries.filter((e) => e.isDirectory()).map((e) => e.name);
+export interface ListContextsOptions {
+  includeMetadata?: boolean;
+  sort?: "name" | "recent_activity" | "created" | "updated";
+  includeArchived?: boolean;
+}
 
-  if (!includeMetadata) {
-    return names.map((name) => ({ name }));
+function isArchived(meta: ContextMetadata | undefined): boolean {
+  return !!meta && meta.status === "archived";
+}
+
+function sortSummaries(
+  summaries: ContextSummary[],
+  sort: NonNullable<ListContextsOptions["sort"]>
+): void {
+  if (sort === "name") {
+    summaries.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+    return;
   }
+  // For time-based sorts, most-recent-first. Missing values sink.
+  const key: keyof ContextMetadata =
+    sort === "recent_activity" ? "last_activity" : sort;
+  summaries.sort((a, b) => {
+    const av = (a.metadata?.[key] as string | undefined) || "";
+    const bv = (b.metadata?.[key] as string | undefined) || "";
+    if (av === bv) return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
+    if (!av) return 1;
+    if (!bv) return -1;
+    return av < bv ? 1 : -1;
+  });
+}
+
+export async function listContexts(
+  opts: ListContextsOptions | boolean = {}
+): Promise<ContextSummary[]> {
+  // Back-compat: legacy signature is listContexts(includeMetadata: boolean)
+  const options: ListContextsOptions =
+    typeof opts === "boolean" ? { includeMetadata: opts } : opts;
+  const sort = options.sort || "name";
+  const includeArchived = options.includeArchived === true;
+  // Any non-name sort, or an archived filter, requires metadata reads.
+  const needMeta =
+    options.includeMetadata === true || sort !== "name" || !includeArchived;
+
+  await ensureDataDir();
+  const entries = await fs.readdir(dataDir(), { withFileTypes: true });
+  const names = entries.filter((e) => e.isDirectory()).map((e) => e.name);
 
   const summaries: ContextSummary[] = [];
   for (const name of names) {
-    try {
-      const metadata = await getContextMetadata(name);
-      summaries.push({ name, metadata });
-    } catch {
-      summaries.push({ name, metadata: defaultContextMetadata() });
+    if (!needMeta) {
+      summaries.push({ name });
+      continue;
     }
+    let metadata: ContextMetadata;
+    try {
+      metadata = await getContextMetadata(name);
+    } catch {
+      metadata = defaultContextMetadata();
+    }
+    if (!includeArchived && isArchived(metadata)) continue;
+    summaries.push({ name, metadata });
+  }
+
+  sortSummaries(summaries, sort);
+
+  if (options.includeMetadata !== true) {
+    return summaries.map((s) => ({ name: s.name }));
   }
   return summaries;
 }
@@ -236,6 +368,7 @@ export async function createContext(name: string): Promise<void> {
   } catch (err: unknown) {
     if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
       await fs.mkdir(dir, { recursive: true });
+      await touchContext(name);
       return;
     }
     throw err;
@@ -289,11 +422,9 @@ async function findItemExtension(
     throw new Error(`Item '${base}' not found in context '${context}'`);
   }
 
-  // Prefer md, otherwise first hit in ITEM_EXTENSIONS order.
   return found.includes("md") ? "md" : found[0];
 }
 
-// Windows reports birthtime reliably; elsewhere we fall back to ctime if zero.
 function statCreatedISO(stat: { birthtime: Date; ctime: Date }): string {
   const bt = stat.birthtime;
   if (bt && bt.getTime() > 0) return bt.toISOString();
@@ -312,7 +443,7 @@ export async function listItems(context: string): Promise<ItemInfo[]> {
   const items: ItemInfo[] = [];
   for (const entry of entries) {
     const parsed = splitItemFilename(entry);
-    if (!parsed) continue; // skips _context.yaml and unsupported files
+    if (!parsed) continue;
 
     const filePath = path.join(dir, entry);
     const stat = await fs.stat(filePath);
@@ -344,7 +475,6 @@ export async function listItems(context: string): Promise<ItemInfo[]> {
     }
   }
 
-  // Updated desc, then name asc.
   items.sort((a, b) => {
     if (a.updated !== b.updated) return a.updated < b.updated ? 1 : -1;
     return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
@@ -394,6 +524,40 @@ export async function getItem(
   };
 }
 
+export interface RawItem {
+  name: string;
+  extension: ItemExtension;
+  filename: string;
+  contentType: string;
+  content: string;
+  size: number;
+}
+
+// Full, byte-for-byte content of an item as stored on disk — including YAML
+// frontmatter for markdown. Distinct from getItem(), which strips frontmatter
+// from md and returns it as a separate field. Used by the UI's Download button
+// and by the `get_item_raw` MCP tool.
+export async function getItemRaw(
+  context: string,
+  base: string,
+  preferred?: ItemExtension
+): Promise<RawItem> {
+  const ext = await findItemExtension(context, base, preferred);
+  const filePath = resolveItemPath(context, base, ext);
+  const [raw, stat] = await Promise.all([
+    fs.readFile(filePath, "utf-8"),
+    fs.stat(filePath),
+  ]);
+  return {
+    name: base,
+    extension: ext,
+    filename: `${base}.${ext}`,
+    contentType: contentTypeFor(ext),
+    content: raw,
+    size: stat.size,
+  };
+}
+
 export async function createItem(
   context: string,
   base: string,
@@ -405,7 +569,6 @@ export async function createItem(
       `Invalid item name '${base}': must start with alphanumeric, letters/digits/hyphens/underscores only`
     );
   }
-  // Defense in depth against reserved filename even though the regex blocks leading underscore.
   if (`${base}.${ext}` === CONTEXT_META_FILENAME) {
     throw new Error(`Reserved filename: '${CONTEXT_META_FILENAME}'`);
   }
@@ -436,11 +599,11 @@ export async function createItem(
           updated: now,
         };
         const output = matter.stringify(opts.content || "", frontmatter);
-        await fs.writeFile(filePath, output, "utf-8");
+        await writeFileAtomic(filePath, output);
       } else {
-        // Non-md: ignore title/tags.
-        await fs.writeFile(filePath, opts.content || "", "utf-8");
+        await writeFileAtomic(filePath, opts.content || "");
       }
+      await touchContext(context);
       return;
     }
     throw err;
@@ -472,11 +635,11 @@ export async function updateItem(
 
     const body = updates.content !== undefined ? updates.content : parsed.content;
     const output = matter.stringify(body, meta);
-    await fs.writeFile(filePath, output, "utf-8");
+    await writeFileAtomic(filePath, output);
+    await touchContext(context);
     return;
   }
 
-  // Non-markdown: content is the only updatable field.
   if (updates.title !== undefined || updates.tags !== undefined) {
     throw new Error(
       `title/tags are not supported on non-markdown items (kind: ${ext})`
@@ -485,7 +648,8 @@ export async function updateItem(
   if (updates.content === undefined) {
     throw new Error(`No content provided to update '${base}.${ext}'`);
   }
-  await fs.writeFile(filePath, updates.content, "utf-8");
+  await writeFileAtomic(filePath, updates.content);
+  await touchContext(context);
 }
 
 export async function appendToItem(
@@ -512,14 +676,15 @@ export async function appendToItem(
 
     const body = parsed.content + "\n\n" + newContent;
     const output = matter.stringify(body, meta);
-    await fs.writeFile(filePath, output, "utf-8");
+    await writeFileAtomic(filePath, output);
+    await touchContext(context);
     return;
   }
 
-  // txt / csv: simple textual append.
   const existing = await fs.readFile(filePath, "utf-8").catch(() => "");
   const sep = existing.length === 0 || existing.endsWith("\n") ? "" : "\n";
-  await fs.writeFile(filePath, existing + sep + newContent, "utf-8");
+  await writeFileAtomic(filePath, existing + sep + newContent);
+  await touchContext(context);
 }
 
 export async function deleteItem(
@@ -529,10 +694,71 @@ export async function deleteItem(
 ): Promise<void> {
   const ext = await findItemExtension(context, base, preferred);
   const filePath = resolveItemPath(context, base, ext);
-  // resolveItemPath can never produce the _context.yaml path (it always
-  // appends a whitelisted extension), so this is safe against accidental
-  // deletion of the metadata file.
   await fs.rm(filePath);
+  await touchContext(context).catch(() => {
+    // If _context.yaml write fails after item delete, don't fail the delete.
+  });
+}
+
+// --- Diagnostics ---
+
+export interface Diagnostics {
+  dataDir: string;
+  configPath: string;
+  version: string;
+  contextCount: number;
+  archivedCount: number;
+  itemCount: number;
+  totalBytes: number;
+  lastScanMs: number;
+}
+
+export async function getDiagnostics(): Promise<Diagnostics> {
+  const cfg = loadConfig();
+  const start = Date.now();
+  await ensureDataDir();
+  const entries = await fs.readdir(cfg.dataDir, { withFileTypes: true });
+  const ctxNames = entries.filter((e) => e.isDirectory()).map((e) => e.name);
+
+  let archivedCount = 0;
+  let itemCount = 0;
+  let totalBytes = 0;
+
+  for (const name of ctxNames) {
+    let meta: ContextMetadata | null = null;
+    try {
+      meta = await getContextMetadata(name);
+    } catch {
+      meta = null;
+    }
+    if (isArchived(meta || undefined)) archivedCount += 1;
+
+    let ents: string[];
+    try {
+      ents = await fs.readdir(path.join(cfg.dataDir, name));
+    } catch {
+      continue;
+    }
+    for (const ent of ents) {
+      const parsed = splitItemFilename(ent);
+      if (!parsed) continue;
+      const st = await fs.stat(path.join(cfg.dataDir, name, ent)).catch(() => null);
+      if (!st || !st.isFile()) continue;
+      itemCount += 1;
+      totalBytes += st.size;
+    }
+  }
+
+  return {
+    dataDir: cfg.dataDir,
+    configPath: cfg.configPath,
+    version: packageVersion(),
+    contextCount: ctxNames.length,
+    archivedCount,
+    itemCount,
+    totalBytes,
+    lastScanMs: Date.now() - start,
+  };
 }
 
 // --- Re-exports for convenience ---

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -56,7 +56,7 @@ export function layout(title: string, body: string): string {
     } catch (e) {}
   })();
   </script>
-  <style>html,body{background:#111;color:#ccc;}html[data-theme="light"],html[data-theme="light"] body{background:#e8e0cc;color:#2a2824;}</style>
+  <style>html,body{background:#16181d;color:#c9d1d9;}html[data-theme="light"],html[data-theme="light"] body{background:#e8e0cc;color:#2a2824;}</style>
   <title>${esc(title)} - Contexts</title>
   <script src="https://unpkg.com/htmx.org@2.0.4"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -72,22 +72,22 @@ export function layout(title: string, body: string): string {
   </script>
   <style>
     :root {
-      --bg: #1a1a1a; --surface: #222222; --surface-raised: #2a2a2a;
-      --border: #444444; --border-heavy: #666666;
-      --text: #cccccc; --text-muted: #777777; --text-bright: #e0e0e0; --text-dim: #555555;
-      --tag-bg: #333333; --tag-text: #bbbbbb;
+      --bg: #1c1f26; --surface: #23262e; --surface-raised: #2c303a;
+      --border: #3d424d; --border-heavy: #5a6070;
+      --text: #c9d1d9; --text-muted: #7d8491; --text-bright: #e6e8ec; --text-dim: #5a6070;
+      --tag-bg: #2c303a; --tag-text: #b4bbc7;
       --accent: #4ade80; --accent-glow: #4ade80;
-      --accent-line: rgba(74,222,128,0.07); --accent-line-hover: rgba(74,222,128,0.6);
-      --selection-bg: #4ade80; --selection-text: #0a0a0a;
-      --body-bg: #111111;
-      --input-bg: #181818; --input-bg-focus: #1d1d1d;
-      --code-bg: #181818; --pre-bg: #141414; --table-stripe: #111111;
-      --hover-text: #ffffff;
-      --btn-shadow: #000000; --btn-primary-text: #000000;
-      --flash-success-bg: #1a1f1a; --flash-error-bg: #1f1a1a; --flash-error-border: #888888;
-      --scanline: rgba(0,0,0,0.04); --vignette: rgba(0,0,0,0.4);
-      --noise-blend: overlay; --noise-opacity: 0.5;
-      --container-shadow: rgba(0,0,0,0.3);
+      --accent-line: rgba(74,222,128,0.08); --accent-line-hover: rgba(74,222,128,0.65);
+      --selection-bg: #4ade80; --selection-text: #0a1209;
+      --body-bg: #16181d;
+      --input-bg: #1d2027; --input-bg-focus: #22262e;
+      --code-bg: #1d2027; --pre-bg: #181b21; --table-stripe: #181b21;
+      --hover-text: #f0f2f5;
+      --btn-shadow: #0c0e12; --btn-primary-text: #111318;
+      --flash-success-bg: #1d2523; --flash-error-bg: #25211d; --flash-error-border: #8a8070;
+      --scanline: rgba(0,0,0,0.035); --vignette: rgba(0,0,0,0.35);
+      --noise-blend: overlay; --noise-opacity: 0.35;
+      --container-shadow: rgba(0,0,0,0.25);
       --sticky-header-h: 4.5rem;
       --sticky-crumb-h: 2.25rem;
     }
@@ -483,6 +483,61 @@ export function layout(title: string, body: string): string {
       letter-spacing: 0.2em; text-transform: uppercase; font-family: 'IBM Plex Mono', monospace;
     }
     .footer-shutdown { display: inline-block; margin: 0.5rem 0 0 0; }
+    .footer-about { display: block; margin: 1rem auto 0; max-width: 32rem; text-align: left; }
+    .footer-about summary {
+      cursor: pointer; color: var(--text-muted); letter-spacing: 0.2em;
+      font-size: 0.6rem; text-align: center; list-style: none;
+    }
+    .footer-about summary::-webkit-details-marker { display: none; }
+    .footer-about summary::before { content: '▸ '; opacity: 0.6; }
+    .footer-about[open] summary::before { content: '▾ '; }
+    .footer-about-body {
+      margin-top: 0.75rem; padding: 0.75rem 1rem;
+      background: var(--code-bg); border: 1px solid var(--border);
+      font-family: 'IBM Plex Mono', monospace; font-size: 0.7rem;
+      letter-spacing: 0.02em; text-transform: none; color: var(--text-muted);
+      white-space: pre-wrap; word-break: break-all;
+    }
+    .footer-about-body dt { color: var(--text-dim); font-size: 0.65rem; text-transform: uppercase; letter-spacing: 0.1em; }
+    .footer-about-body dd { margin: 0 0 0.4rem 0; color: var(--text); }
+    .footer-about-body dd:last-child { margin-bottom: 0; }
+
+    /* --- List header controls --- */
+    .list-controls {
+      display: flex; flex-wrap: wrap; gap: 0.5rem 0.75rem; align-items: center;
+      margin: 0.75rem 0 1rem 0; padding: 0.5rem 0.75rem;
+      border: 1px dotted var(--border); background: var(--surface);
+      font-size: 0.7rem; color: var(--text-muted);
+      text-transform: uppercase; letter-spacing: 0.08em;
+    }
+    .list-controls .list-label {
+      color: var(--text-dim); font-size: 0.65rem; margin-right: 0.1rem;
+    }
+    .sort-tab {
+      display: inline-block; padding: 0.15rem 0.5rem;
+      font-size: 0.7rem; color: var(--text-muted);
+      border: 1px solid transparent; border-bottom: 1px dotted var(--text-dim);
+      text-transform: uppercase; letter-spacing: 0.08em;
+    }
+    .sort-tab:hover {
+      color: var(--text-bright); border-color: var(--border);
+      border-bottom-style: solid; background: var(--surface-raised);
+    }
+    .sort-tab.active {
+      color: var(--accent); background: var(--surface-raised);
+      border-color: var(--accent); border-bottom: 1px solid var(--accent);
+      text-shadow: 0 0 6px var(--accent-glow);
+    }
+    .sort-tab.active::before { content: '▸ '; color: var(--accent); }
+    .list-controls .chip {
+      display: inline-flex; align-items: center; gap: 0.3rem;
+      margin-left: auto;
+      padding: 0.15rem 0.55rem; font-size: 0.65rem;
+      background: var(--surface-raised); border: 1px dotted var(--border);
+      color: var(--text-muted);
+    }
+    .list-controls .chip::before { content: '▮'; color: var(--text-dim); font-size: 0.55rem; }
+    .list-controls .chip:hover { color: var(--text-bright); border-style: solid; }
 
     /* --- Selection --- */
     ::selection { background: var(--selection-bg); color: var(--selection-text); text-shadow: none; }
@@ -524,7 +579,11 @@ export function layout(title: string, body: string): string {
     </header>
     ${body}
     <footer class="classification-footer">
-      <span id="footer-text">CONTEXT MANAGEMENT SYSTEM v1.1 &mdash; TERMINAL ${terminalId} &mdash; SESSION ACTIVE</span>
+      <span id="footer-text">CONTEXT MANAGEMENT SYSTEM &mdash; TERMINAL ${terminalId} &mdash; SESSION ACTIVE</span>
+      <details id="footer-about" class="footer-about">
+        <summary>About</summary>
+        <div id="footer-about-body">loading...</div>
+      </details>
       <form hx-post="/shutdown" hx-confirm="Shut down the Contexts UI server?" hx-target="#footer-text" hx-swap="outerHTML" class="footer-shutdown">
         <button type="submit" class="btn btn-sm btn-danger">× Shutdown</button>
       </form>
@@ -622,6 +681,60 @@ export function layout(title: string, body: string): string {
       render();
     });
   })();
+  (function() {
+    var about = document.getElementById('footer-about');
+    var body = document.getElementById('footer-about-body');
+    if (!about || !body) return;
+    var loaded = false;
+    about.addEventListener('toggle', function() {
+      if (!about.open || loaded) return;
+      loaded = true;
+      body.className = 'footer-about-body';
+      fetch('/diagnose').then(function(r){ return r.json(); }).then(function(d){
+        function esc(s){ return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+        body.innerHTML =
+          '<dl>' +
+          '<dt>version</dt><dd>' + esc(d.version) + '</dd>' +
+          '<dt>data dir</dt><dd>' + esc(d.dataDir) + '</dd>' +
+          '<dt>config</dt><dd>' + esc(d.configPath) + '</dd>' +
+          '<dt>contexts</dt><dd>' + d.contextCount + ' (' + d.archivedCount + ' archived)</dd>' +
+          '<dt>items</dt><dd>' + d.itemCount + ' (' + (d.totalBytes/1024).toFixed(1) + ' kB)</dd>' +
+          '<dt>scan</dt><dd>' + d.lastScanMs + ' ms</dd>' +
+          '</dl>';
+      }).catch(function(err){
+        body.textContent = 'diagnose failed: ' + err.message;
+      });
+    });
+  })();
+  (function() {
+    // Per-item Copy button — fetches the raw content from /raw and writes to
+    // clipboard. Markdown strips YAML frontmatter unless Alt is held.
+    document.addEventListener('click', function(ev) {
+      var btn = ev.target.closest && ev.target.closest('[data-copy-raw]');
+      if (!btn) return;
+      ev.preventDefault();
+      var url = btn.getAttribute('data-copy-raw');
+      var ext = btn.getAttribute('data-ext');
+      var withFrontmatter = ev.altKey;
+      fetch(url).then(function(r){ return r.text(); }).then(function(raw) {
+        var out = raw;
+        if (ext === 'md' && !withFrontmatter) {
+          var m = raw.match(/^---\\n[\\s\\S]*?\\n---\\n?/);
+          if (m) out = raw.slice(m[0].length);
+        }
+        return (navigator.clipboard && navigator.clipboard.writeText)
+          ? navigator.clipboard.writeText(out)
+          : Promise.reject(new Error('clipboard unavailable'));
+      }).then(function() {
+        var original = btn.textContent;
+        btn.textContent = 'Copied';
+        setTimeout(function(){ btn.textContent = original; }, 1200);
+      }).catch(function(err){
+        btn.textContent = 'Copy failed';
+        setTimeout(function(){ btn.textContent = 'Copy'; }, 1500);
+      });
+    });
+  })();
   </script>
 </body>
 </html>`;
@@ -660,7 +773,16 @@ function renderContextCardBody(summary: ContextSummary): string {
     </div>`;
 }
 
-export function contextListPage(contexts: ContextSummary[]): string {
+export interface ContextListControls {
+  sort: "name" | "recent_activity" | "created" | "updated";
+  showArchived: boolean;
+  archivedCount: number;
+}
+
+export function contextListPage(
+  contexts: ContextSummary[],
+  controls: ContextListControls
+): string {
   const list = contexts.length
     ? contexts
         .map(
@@ -670,10 +792,44 @@ export function contextListPage(contexts: ContextSummary[]): string {
         .join("")
     : `<div class="empty">No contexts yet. Create one below.</div>`;
 
+  const sortOptions: Array<{ v: ContextListControls["sort"]; label: string }> = [
+    { v: "name", label: "name" },
+    { v: "recent_activity", label: "recent" },
+    { v: "updated", label: "updated" },
+    { v: "created", label: "created" },
+  ];
+  // Plain links instead of a <select> — the native select shows the CRT
+  // scanline overlay, which reads as visual garbage on a small control.
+  const sortParam = (v: string) =>
+    controls.showArchived ? `?sort=${v}&show_archived=1` : `?sort=${v}`;
+  const sortTabs = sortOptions
+    .map(
+      (o) =>
+        `<a class="sort-tab${o.v === controls.sort ? " active" : ""}" href="${sortParam(o.v)}">${o.label}</a>`
+    )
+    .join("");
+
+  const archivedToggleHref = controls.showArchived
+    ? `?sort=${esc(controls.sort)}`
+    : `?sort=${esc(controls.sort)}&show_archived=1`;
+  const archivedChip = controls.archivedCount > 0 || controls.showArchived
+    ? `<a class="chip" href="${archivedToggleHref}">${
+        controls.showArchived ? "hide archived" : `archived (${controls.archivedCount})`
+      }</a>`
+    : "";
+
+  const controlsRow = `
+    <div class="list-controls">
+      <span class="list-label">sort by</span>
+      ${sortTabs}
+      ${archivedChip}
+    </div>`;
+
   return layout(
     "All Contexts",
     `
     <h2>Contexts</h2>
+    ${controlsRow}
     <div id="context-list" style="margin-top:1rem;">${list}</div>
     <div class="card" style="margin-top:2rem;">
       <h3>New Context</h3>
@@ -714,6 +870,7 @@ export function contextMetaHeader(name: string, meta: ContextMetadata): string {
       ${links}
       <div class="ctx-meta-actions">
         <a href="/ctx/${esc(name)}/meta/edit" class="btn btn-sm">Edit Metadata</a>
+        <a href="/ctx/${esc(name)}.zip" class="btn btn-sm" download>Download .zip</a>
       </div>
     </div>`;
 }
@@ -779,6 +936,7 @@ export function itemListPage(
               <option value="json">JSON (.json)</option>
               <option value="yaml">YAML (.yaml)</option>
               <option value="csv">CSV (.csv)</option>
+              <option value="sql">SQL (.sql)</option>
             </select>
           </div>
         </div>
@@ -803,9 +961,11 @@ export function itemViewPage(
   created: string,
   updated: string,
   contentHtml: string,
-  isMarkdown: boolean
+  isMarkdown: boolean,
+  rawMode: boolean = false,
 ): string {
-  const appendSupported = isMarkdown || extension === "txt" || extension === "csv";
+  const appendSupported =
+    !rawMode && (isMarkdown || extension === "txt" || extension === "csv" || extension === "sql");
   const appendForm = appendSupported
     ? `<div class="card" style="margin-top:2rem;">
       <h3>Append Content</h3>
@@ -814,15 +974,23 @@ export function itemViewPage(
         <button type="submit" class="btn btn-primary">Append</button>
       </form>
     </div>`
-    : `<div class="empty" style="margin-top:2rem;">Append is not supported for structured data items (.json, .yaml, .yml). Use Edit to replace the full content.</div>`;
+    : rawMode
+      ? ""
+      : `<div class="empty" style="margin-top:2rem;">Append is not supported for structured data items (.json, .yaml, .yml). Use Edit to replace the full content.</div>`;
 
-  const contentClass = isMarkdown ? "doc-content" : "doc-content doc-content-raw";
+  const showAsRaw = rawMode || !isMarkdown;
+  const contentClass = showAsRaw ? "doc-content doc-content-raw" : "doc-content";
+
+  const rawUrl = `/ctx/${esc(context)}/${esc(name)}/raw?ext=${esc(extension)}`;
+  const viewUrl = `/ctx/${esc(context)}/${esc(name)}?ext=${esc(extension)}`;
+  const rawToggleHref = rawMode ? viewUrl : `${viewUrl}&raw=1`;
+  const rawToggleLabel = rawMode ? "Rendered" : "Raw";
 
   return layout(
     title,
     `
     <div class="breadcrumb">
-      <a href="/">Contexts</a> / <a href="/ctx/${esc(context)}">${esc(context)}</a> / <strong>${esc(name)}.${esc(extension)}</strong>
+      <a href="/">Contexts</a> / <a href="/ctx/${esc(context)}">${esc(context)}</a> / <strong>${esc(name)}.${esc(extension)}</strong>${rawMode ? ' <span style="color:var(--text-dim);">(raw)</span>' : ""}
     </div>
     <div class="item-title-sticky">
       <div>
@@ -835,6 +1003,9 @@ export function itemViewPage(
         ${tagList.length ? `<div style="margin-top:0.5rem;">${tags(tagList)}</div>` : ""}
       </div>
       <div class="actions">
+        <button type="button" class="btn btn-sm" data-copy-raw="${rawUrl}" data-ext="${esc(extension)}" title="${isMarkdown ? "Copy body (Alt = include frontmatter)" : "Copy raw content"}">Copy</button>
+        <a class="btn btn-sm" href="${rawUrl}&amp;download=1">Download</a>
+        <a class="btn btn-sm" href="${rawToggleHref}">${rawToggleLabel}</a>
         <a href="/ctx/${esc(context)}/${esc(name)}/edit?ext=${esc(extension)}" class="btn btn-sm">Edit</a>
       </div>
     </div>
@@ -942,7 +1113,8 @@ export function searchPage(
   results: SearchResult[] | null,
   query: string,
   contextFilter: string,
-  contexts: string[]
+  contexts: string[],
+  includeArchived: boolean = false,
 ): string {
   const contextOptions = contexts
     .map(
@@ -986,6 +1158,10 @@ export function searchPage(
           </select>
         </div>
       </div>
+      <label style="font-size:0.75rem; display:flex; gap:0.5rem; align-items:center; margin:0.5rem 0;">
+        <input type="checkbox" name="show_archived" value="1" ${includeArchived ? "checked" : ""} style="width:auto; margin:0;">
+        Include archived contexts
+      </label>
       <button type="submit" class="btn btn-primary">Search</button>
     </form>
     <div style="margin-top:1.5rem;">${resultHtml}</div>`

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 // --- Constants ---
 
-export const ITEM_EXTENSIONS = ["md", "txt", "json", "yaml", "yml", "csv"] as const;
+export const ITEM_EXTENSIONS = ["md", "txt", "json", "yaml", "yml", "csv", "sql"] as const;
 export type ItemExtension = (typeof ITEM_EXTENSIONS)[number];
 
 export const CONTEXT_META_FILENAME = "_context.yaml";
@@ -29,6 +29,9 @@ export interface ContextMetadata {
   links: ContextLink[];
   created: string;
   updated: string;
+  // ISO timestamp of the last item-level mutation (create/update/append/delete).
+  // Bumped by storage automatically; callers never set this directly.
+  last_activity?: string;
 }
 
 export interface ContextSummary {
@@ -87,7 +90,16 @@ export const ContextMetadataSchema = z.object({
   links: z.array(ContextLinkSchema).default([]),
   created: z.string().optional(),
   updated: z.string().optional(),
+  last_activity: z.string().optional(),
 });
+
+export const ListContextsSortSchema = z.enum([
+  "name",
+  "recent_activity",
+  "created",
+  "updated",
+]);
+export type ListContextsSort = z.infer<typeof ListContextsSortSchema>;
 
 // --- Tool input schemas ---
 
@@ -96,7 +108,16 @@ export const ListContextsArgsSchema = z.object({
     .boolean()
     .optional()
     .default(false)
-    .describe("If true, also return title, description, status, tags, and links for each context. Slightly slower."),
+    .describe("If true, also return title, description, status, tags, links, and last_activity for each context. Slightly slower."),
+  sort: ListContextsSortSchema
+    .optional()
+    .default("name")
+    .describe("Sort order. 'name' (default, alphabetical) or 'recent_activity' | 'created' | 'updated' (most-recent first)."),
+  include_archived: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe("If false (default), contexts with status='archived' are filtered out. Set true to include them."),
 });
 
 export const CreateContextArgsSchema = z.object({
@@ -198,6 +219,21 @@ export const SearchContextsArgsSchema = z.object({
     .array(z.string())
     .optional()
     .describe("Only search contexts whose metadata tags include any of these"),
+  include_archived: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe("If false (default), contexts with status='archived' are skipped. Set true to include them."),
 });
+
+export const GetItemRawArgsSchema = z.object({
+  context: z.string().describe("Name of the context folder"),
+  item: z.string().describe("Item base name (without extension)"),
+  extension: ItemExtensionSchema
+    .optional()
+    .describe("Optional extension disambiguator if two items share a base name"),
+});
+
+export const ContextDiagnoseArgsSchema = z.object({});
 
 export const ContextMigrationBriefArgsSchema = z.object({});

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,14 +1,20 @@
 #!/usr/bin/env node
 import express from "express";
+import archiver from "archiver";
+import fs from "fs";
+import path from "path";
 import { marked } from "marked";
 import * as storage from "./storage.js";
 import { searchContexts } from "./search.js";
 import {
+  CONTEXT_META_FILENAME,
   CONTEXT_NAME_REGEX,
   ContextLink,
   ITEM_EXTENSIONS,
   ITEM_NAME_REGEX,
   ItemExtension,
+  ListContextsSort,
+  ListContextsSortSchema,
 } from "./types.js";
 import {
   layout,
@@ -21,6 +27,7 @@ import {
   itemEditPage,
   searchPage,
 } from "./templates.js";
+import { loadConfig, MissingDataDirError, packageVersion } from "./config.js";
 
 const app = express();
 app.use(express.urlencoded({ extended: true }));
@@ -31,7 +38,6 @@ function escHtml(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
-// Custom fenced-code renderer: tag <pre> with data-lang so CSS can label it.
 marked.use({
   renderer: {
     code({ text, lang }: { text: string; lang?: string }) {
@@ -51,6 +57,18 @@ function parseExtQuery(raw: unknown): ItemExtension | undefined {
   return undefined;
 }
 
+function parseSort(raw: unknown): ListContextsSort {
+  if (typeof raw === "string") {
+    const parsed = ListContextsSortSchema.safeParse(raw);
+    if (parsed.success) return parsed.data;
+  }
+  return "name";
+}
+
+function parseTruthy(raw: unknown): boolean {
+  return raw === "1" || raw === "true" || raw === "on";
+}
+
 function parseTags(raw: unknown): string[] {
   if (typeof raw !== "string") return [];
   return raw
@@ -61,9 +79,22 @@ function parseTags(raw: unknown): string[] {
 
 // --- Context routes ---
 
-app.get("/", async (_req, res) => {
-  const contexts = await storage.listContexts(true);
-  res.send(contextListPage(contexts));
+app.get("/", async (req, res) => {
+  const sort = parseSort(req.query.sort);
+  const showArchived = parseTruthy(req.query.show_archived);
+  const contexts = await storage.listContexts({
+    includeMetadata: true,
+    sort,
+    includeArchived: showArchived,
+  });
+  // Second read only when needed: a separate call for archived count keeps
+  // the primary grid query cheap when the toggle is off.
+  let archivedCount = 0;
+  if (!showArchived) {
+    const all = await storage.listContexts({ includeMetadata: true, includeArchived: true });
+    archivedCount = all.filter((c) => c.metadata?.status === "archived").length;
+  }
+  res.send(contextListPage(contexts, { sort, showArchived, archivedCount }));
 });
 
 app.post("/ctx", async (req, res) => {
@@ -95,7 +126,6 @@ app.delete("/ctx/:name", async (req, res) => {
 
 app.get("/ctx/:context/meta/edit", async (req, res) => {
   try {
-    // Verify the context exists to produce a clean 404.
     await storage.listItems(req.params.context);
     const meta = await storage.getContextMetadata(req.params.context);
     res.send(contextMetaEditPage(req.params.context, meta));
@@ -128,6 +158,45 @@ app.post("/ctx/:context/meta", async (req, res) => {
   }
 });
 
+// --- Context zip download ---
+
+app.get("/ctx/:context.zip", async (req, res) => {
+  const ctx = req.params.context;
+  try {
+    // Confirm the context exists and is safe to serve — listItems throws for
+    // invalid names, so the zip route inherits the same path-safety guard.
+    await storage.listItems(ctx);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    res.status(404).send(msg);
+    return;
+  }
+
+  res.setHeader("Content-Type", "application/zip");
+  res.setHeader("Content-Disposition", `attachment; filename="${ctx}.zip"`);
+
+  const archive = archiver("zip", { zlib: { level: 9 } });
+  archive.on("error", (err) => {
+    res.status(500).end(err.message);
+  });
+  archive.pipe(res);
+
+  const dir = path.join(storage.getDataDir(), ctx);
+  const entries = fs.readdirSync(dir);
+  for (const entry of entries) {
+    // Include the _context.yaml metadata file too; skip the version stamp and
+    // anything that doesn't look like a supported item file.
+    if (entry === storage.VERSION_STAMP_FILENAME) continue;
+    if (entry.startsWith(".")) continue;
+    const full = path.join(dir, entry);
+    const stat = fs.statSync(full);
+    if (!stat.isFile()) continue;
+    if (entry !== CONTEXT_META_FILENAME && !storage.splitItemFilename(entry)) continue;
+    archive.file(full, { name: entry });
+  }
+  await archive.finalize();
+});
+
 // --- Item routes ---
 
 app.get("/ctx/:context", async (req, res) => {
@@ -155,7 +224,6 @@ app.post("/ctx/:context/items", async (req, res) => {
       tags,
       content: content || "",
     });
-    // Re-read to get the persisted metadata/fs stats.
     const items = await storage.listItems(req.params.context);
     const created = items.find((i) => i.name === item && i.extension === ext);
     if (!created) throw new Error("Item created but could not be re-read");
@@ -166,15 +234,42 @@ app.post("/ctx/:context/items", async (req, res) => {
   }
 });
 
+// Raw-bytes item route — used by the UI Download button and direct tooling.
+app.get("/ctx/:context/:item/raw", async (req, res) => {
+  try {
+    const { context, item: itemName } = req.params;
+    const preferred = parseExtQuery(req.query.ext);
+    const raw = await storage.getItemRaw(context, itemName, preferred);
+    const disposition = parseTruthy(req.query.download) ? "attachment" : "inline";
+    res.setHeader("Content-Type", raw.contentType);
+    res.setHeader(
+      "Content-Disposition",
+      `${disposition}; filename="${raw.filename}"`
+    );
+    res.send(raw.content);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    res.status(404).type("text/plain").send(msg);
+  }
+});
+
 app.get("/ctx/:context/:item", async (req, res) => {
   try {
     const { context, item: itemName } = req.params;
     const preferred = parseExtQuery(req.query.ext);
+    const rawMode = parseTruthy(req.query.raw);
     const item = await storage.getItem(context, itemName, preferred);
     const isMarkdown = item.extension === "md";
-    const contentHtml = isMarkdown
-      ? await marked.parse(item.content)
-      : escHtml(item.content);
+    let contentHtml: string;
+    if (rawMode) {
+      // Always show the verbatim file content in raw mode (md includes frontmatter).
+      const rawItem = await storage.getItemRaw(context, itemName, preferred);
+      contentHtml = escHtml(rawItem.content);
+    } else if (isMarkdown) {
+      contentHtml = await marked.parse(item.content);
+    } else {
+      contentHtml = escHtml(item.content);
+    }
     const fm = item.frontmatter;
     res.send(
       itemViewPage(
@@ -186,7 +281,8 @@ app.get("/ctx/:context/:item", async (req, res) => {
         item.created,
         item.updated,
         contentHtml,
-        isMarkdown
+        isMarkdown,
+        rawMode,
       )
     );
   } catch (err: unknown) {
@@ -273,42 +369,69 @@ app.delete("/ctx/:context/:item", async (req, res) => {
 app.get("/search", async (req, res) => {
   const q = (req.query.q as string) || "";
   const context = (req.query.context as string) || "";
-  const contexts = await storage.listContexts(false);
+  const includeArchived = parseTruthy(req.query.show_archived);
+  const contexts = await storage.listContexts({ includeArchived: true });
   const contextNames = contexts.map((c) => c.name);
 
   if (!q) {
-    res.send(searchPage(null, "", "", contextNames));
+    res.send(searchPage(null, "", "", contextNames, includeArchived));
     return;
   }
 
   const results = await searchContexts(storage.getDataDir(), q, {
     contextFilter: context || undefined,
+    includeArchived,
   });
-  res.send(searchPage(results, q, context, contextNames));
+  res.send(searchPage(results, q, context, contextNames, includeArchived));
+});
+
+// --- Diagnose ---
+
+app.get("/diagnose", async (_req, res) => {
+  const diag = await storage.getDiagnostics();
+  res.json(diag);
 });
 
 // --- Shutdown ---
 
+// Invariant: the shutdown handler MUST NOT write to the data dir. Shutdown is
+// release-the-port only — any mid-flight storage write is expected to finish
+// before the 200ms timer fires, and we do not rewrite metadata on exit.
 app.post("/shutdown", (_req, res) => {
   res.send(
     `<span id="footer-text">SERVER TERMINATED &mdash; PORT ${PORT} RELEASED</span>`
   );
-  // Flush the response before the process exits.
   setTimeout(() => process.exit(0), 200);
 });
 
 // --- Start ---
 
-const PORT = parseInt(process.env.CONTEXTS_UI_PORT || "3141", 10);
+let PORT = 3141;
 
 async function main() {
-  await storage.ensureDataDir();
+  try {
+    const cfg = loadConfig();
+    PORT = cfg.uiPort;
+    console.error(`[contexts-mcp-ui] version:   ${packageVersion()}`);
+    console.error(`[contexts-mcp-ui] data dir:  ${cfg.dataDir} (from ${cfg.source.dataDir})`);
+    console.error(`[contexts-mcp-ui] config:    ${cfg.configPath}`);
+    await storage.ensureDataDir();
+  } catch (err) {
+    if (err instanceof MissingDataDirError) {
+      console.error("[contexts-mcp-ui] startup failed — no data dir configured.");
+      console.error("");
+      console.error(err.message);
+      process.exit(1);
+    }
+    throw err;
+  }
+
   app.listen(PORT, () => {
     console.log(`Contexts UI running at http://localhost:${PORT}`);
   });
 }
 
 main().catch((err) => {
-  console.error("Fatal:", err);
+  console.error("[contexts-mcp-ui] Fatal:", err);
   process.exit(1);
 });


### PR DESCRIPTION
## Summary

Addresses `install-and-pathing-improvements.md` §1, 3, 4, 6, 7, 8, 9, 10, 12, 13, 14, 15, 16, 17.

- **Config & setup**: new `src/config.ts` (OS-aware config file, env > file > friendly error — no more silent cwd fallback) and interactive `src/setup.ts` behind `npm run setup`, which is now the single "run this again" command. Startup logs the resolved data dir / config path / version to stderr.
- **Storage safety**: atomic `tmp+rename` writes everywhere, `.contexts-mcp-version` stamp at the data-dir root, `/shutdown` is explicitly zero-write.
- **New data-model bits**: auto-tracked `last_activity` in `_context.yaml`; `status: 'archived'` is now a convention that filters out of default list/search unless `include_archived=true`; `sql` added to `ITEM_EXTENSIONS`.
- **New tools & routes**: `context_diagnose` (+ `GET /diagnose`) returns `{dataDir, configPath, version, contextCount, archivedCount, itemCount, totalBytes, lastScanMs}`. `get_item_raw` + `GET /ctx/:c/:i/raw` stream byte-for-byte content. `GET /ctx/:c.zip` streams the whole context.
- **UI**: per-item Copy (body by default, Alt = include frontmatter) / Download / Raw buttons; sort-by tabs + archive toggle (tabs not a `<select>` so scanlines don't bleed through); context-level Download `.zip`; live About disclosure in the footer; dark-mode palette softened for long-form reading while keeping the vibrant `#4ade80` accent for selection, active tab (with text-shadow glow), and card hover.
- **Dev affordances**: `scripts/sanity.js` (7 invariants), `scripts/bench.js` (p50/p95/p99 on create/update/list/diagnose), `bin/contexts-mcp-ui.js` cross-platform launcher.
- **Docs**: README rewrite with a "one command you actually need to remember" block + re-running table up top, HTTPS clone; new `docs/claude-code-setup.md` with the preapproval block for Claude Code sub-agents.

### Deferred (intentional)

- §5 import `<dir>` CLI — `context_migration_brief` still covers the rules.
- §14 `_index.json` cache — measure via `/diagnose` before optimizing.
- §9 LaunchAgent / systemd templates — `bin/contexts-mcp-ui` covers the common case.

## Test plan

- [ ] `npm install && npm run build` succeeds from a clean clone.
- [ ] `npm run setup` prompts for data dir + port and writes `config.json` at the OS-appropriate path.
- [ ] Deleting `config.json` and starting the server with no env var produces the friendly `"Run: npm run setup"` error (exit 1) — **no** silent cwd fallback.
- [ ] `node scripts/sanity.js` — all 7 invariants pass.
- [ ] `node scripts/bench.js` completes and prints a p50/p95/p99 table.
- [ ] `context_diagnose` via MCP returns the correct counts and matches `GET /diagnose` on the UI.
- [ ] `list_contexts` with `sort: "recent_activity"` returns most-recently-touched contexts first.
- [ ] A context with `status: "archived"` is absent from default `list_contexts` / `search_contexts`, present when `include_archived: true`.
- [ ] UI Copy copies body-only for md (Alt copies with frontmatter), Copy copies raw for non-md.
- [ ] UI Download streams the file with correct `Content-Type` and filename.
- [ ] `/ctx/<name>.zip` is a valid zip including `_context.yaml` + all items.
- [ ] Dark mode: accents on active sort tab, selection, and card hover read clearly as phosphor green; body text is softer than before.
- [ ] `create_item` with `extension: "sql"` succeeds; `append_to_item` works on sql (still errors on json/yaml/yml).
- [ ] On Windows, `npm run setup` offers to refresh the Desktop shortcut and it points at the current install path.