### PR TITLE
Web UI fixes from two autonomous dogfood walkthroughs (14 defects)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ contexts-data/
 
 # Local editor settings (personal Peacock colors, machine-specific)
 .vscode/
+
+# Autonomous QA walkthrough artifacts (screenshots, scratch)
+.qa-screens/

--- a/scripts/ui-sandbox.js
+++ b/scripts/ui-sandbox.js
@@ -1,0 +1,131 @@
+// ui-sandbox.js — launch a DISPOSABLE contexts web UI for autonomous walkthroughs.
+//
+// Spins up dist/web.js against a throwaway temp dataDir on a free ephemeral port,
+// seeded with a fixture that exercises the real surface (multiple item kinds, an
+// archived context, a search target, metadata + links). Prints one machine-readable
+// line `SANDBOX_READY {json}` once the server is serving, then stays alive until
+// killed (SIGINT/SIGTERM), at which point it tears the child + temp dir down.
+//
+// This is the safe instance the roaming/dogfood agents drive — it can be trashed
+// freely without touching the user's real contexts.
+//
+//   node scripts/ui-sandbox.js            # seed fixtures, run until Ctrl-C
+//   KEEP=1 node scripts/ui-sandbox.js     # leave temp dataDir on exit (for inspection)
+
+import { spawn } from "child_process";
+import net from "net";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "..");
+const webEntry = path.join(repoRoot, "dist", "web.js");
+
+function freePort() {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.once("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const { port } = srv.address();
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+// --- Fixture: written as plain files, exactly how storage reads them back. ---
+function seed(dataDir) {
+  const write = (rel, body) => {
+    const full = path.join(dataDir, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, body, "utf-8");
+  };
+
+  // A rich, in-progress context: md w/ frontmatter, a plain txt, full metadata.
+  write(
+    "alpha-notes/_context.yaml",
+    [
+      "title: Alpha Notes",
+      "description: Primary working context for the walkthrough.",
+      "status: in-progress",
+      "tags:",
+      "  - demo",
+      "  - walk",
+      "links:",
+      "  - label: Project home",
+      "    url: https://example.com/alpha",
+      "",
+    ].join("\n"),
+  );
+  write(
+    "alpha-notes/readme.md",
+    ["---", "title: Read Me First", "tags: [intro, guide]", "---", "", "# Alpha", "", "Some **markdown** with a [link](https://example.com).", ""].join("\n"),
+  );
+  write("alpha-notes/scratch.txt", "plain text item, no frontmatter, nothing fancy\n");
+
+  // A bare context (no _context.yaml) holding the structured kinds.
+  write("data-bits/config.json", JSON.stringify({ enabled: true, retries: 3, name: "demo" }, null, 2) + "\n");
+  write("data-bits/rows.csv", "id,name,score\n1,alpha,90\n2,beta,75\n");
+  write("data-bits/settings.yaml", ["mode: fast", "limit: 10", "flags:", "  - a", "  - b", ""].join("\n"));
+
+  // An archived context — must be hidden from the default list, shown when opted in.
+  write("archived-thing/_context.yaml", ["title: Old Archived Thing", "status: archived", "tags: [old]", ""].join("\n"));
+  write("archived-thing/old.md", ["---", "title: Stale", "---", "", "Archived content.", ""].join("\n"));
+
+  // A search target with a distinctive token, for exercising full-text search.
+  write("query-target/_context.yaml", ["title: Query Target", "status: active", "tags: [search]", ""].join("\n"));
+  write("query-target/findme.md", ["---", "title: Find Me", "---", "", "The magic token is ZEBRAFISH and it appears exactly once.", ""].join("\n"));
+}
+
+async function main() {
+  const port = await freePort();
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "contexts-ui-sandbox-"));
+  seed(dataDir);
+
+  const child = spawn(process.execPath, [webEntry], {
+    env: { ...process.env, CONTEXTS_DATA_DIR: dataDir, CONTEXTS_UI_PORT: String(port) },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let announced = false;
+  const url = `http://localhost:${port}`;
+  const announce = () => {
+    if (announced) return;
+    announced = true;
+    process.stdout.write(`SANDBOX_READY ${JSON.stringify({ url, dataDir, pid: child.pid, port })}\n`);
+  };
+
+  child.stdout.on("data", (b) => {
+    const s = b.toString();
+    process.stderr.write(`[ui] ${s}`);
+    if (s.includes("Contexts UI running")) announce();
+  });
+  child.stderr.on("data", (b) => process.stderr.write(`[ui:err] ${b}`));
+
+  // Fallback: the ready line is on stdout, but announce on a timer too in case
+  // buffering hides it — the server is listening well before this fires.
+  setTimeout(announce, 2500);
+
+  let cleaning = false;
+  const cleanup = (code) => {
+    if (cleaning) return;
+    cleaning = true;
+    try { child.kill(); } catch {}
+    if (!process.env.KEEP) {
+      try { fs.rmSync(dataDir, { recursive: true, force: true }); } catch {}
+    } else {
+      process.stderr.write(`[sandbox] kept dataDir: ${dataDir}\n`);
+    }
+    process.exit(code ?? 0);
+  };
+
+  process.on("SIGINT", () => cleanup(0));
+  process.on("SIGTERM", () => cleanup(0));
+  child.on("exit", (code) => cleanup(code ?? 0));
+}
+
+main().catch((err) => {
+  process.stderr.write(`[sandbox] failed: ${err?.stack || err}\n`);
+  process.exit(1);
+});

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,7 +1,7 @@
 import fs from "fs/promises";
 import path from "path";
 import matter from "gray-matter";
-import { ContextMetadata, ItemExtension } from "./types.js";
+import { ContextMetadata, ItemExtension, CONTEXT_NAME_REGEX } from "./types.js";
 import { getContextMetadata, splitItemFilename } from "./storage.js";
 
 export interface SearchResult {
@@ -36,7 +36,7 @@ interface ItemContent {
 }
 
 async function selectContexts(dataDir: string, contextFilter?: string): Promise<string[]> {
-  if (contextFilter) return [contextFilter];
+  if (contextFilter) return CONTEXT_NAME_REGEX.test(contextFilter) ? [contextFilter] : [];
   const entries = await fs.readdir(dataDir, { withFileTypes: true });
   return entries.filter((e) => e.isDirectory()).map((e) => e.name);
 }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -390,7 +390,20 @@ export async function createContext(name: string): Promise<void> {
     throw new Error(`Context '${name}' already exists`);
   } catch (err: unknown) {
     if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
-      await fs.mkdir(dir, { recursive: true });
+      try {
+        await fs.mkdir(dir, { recursive: true });
+      } catch (mkErr: unknown) {
+        // The name passed the regex but the OS rejected the resulting path
+        // (typically too long). Normalize rather than leak the absolute path.
+        const code =
+          mkErr instanceof Error && "code" in mkErr
+            ? (mkErr as NodeJS.ErrnoException).code
+            : undefined;
+        if (code === "ENAMETOOLONG" || code === "ENOENT" || code === "EINVAL") {
+          throw new Error(`Invalid context name '${name}': name too long`);
+        }
+        throw mkErr;
+      }
       await touchContext(name);
       return;
     }
@@ -400,7 +413,9 @@ export async function createContext(name: string): Promise<void> {
 
 export async function deleteContext(name: string): Promise<void> {
   const dir = resolveContextPath(name);
-  await fs.access(dir);
+  await fs.access(dir).catch(() => {
+    throw new Error(`Context '${name}' not found`);
+  });
   await fs.rm(dir, { recursive: true, force: true });
 }
 

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -417,7 +417,8 @@ export function contextListPage(
     ${contextListRegionFragment(contexts, controls)}
     <div class="card" style="margin-top:2rem;">
       <h3>New Context</h3>
-      <form hx-post="/ctx" hx-target="#context-list" hx-swap="beforeend" hx-on::after-request="if(event.detail.successful) this.reset()">
+      <div id="new-ctx-error"></div>
+      <form hx-post="/ctx" hx-target="#context-list" hx-swap="beforeend" hx-on::after-request="var slot=document.getElementById('new-ctx-error');if(event.detail.successful){this.reset();slot.innerHTML='';}else{slot.innerHTML=event.detail.xhr.responseText;}">
         <label for="name">Name</label>
         <input type="text" id="name" name="name" pattern="[a-zA-Z0-9_-]+" required placeholder="my-project">
         <button type="submit" class="btn btn-primary">Create</button>
@@ -621,6 +622,7 @@ export function itemListPage(
               <option value="txt">Plain text (.txt)</option>
               <option value="json">JSON (.json)</option>
               <option value="yaml">YAML (.yaml)</option>
+              <option value="yml">YAML (.yml)</option>
               <option value="csv">CSV (.csv)</option>
               <option value="sql">SQL (.sql)</option>
             </select>

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -1041,7 +1041,15 @@ export function themeLabPage(): string {
       }
       function resetAll() {
         DIMENSIONS.forEach(function(k) { root.removeAttribute('data-' + k); });
-        try { localStorage.removeItem(KEY); } catch (e) {}
+        try {
+          // Remove only the theme DIMENSION keys, preserving sibling keys (e.g.
+          // the header's 'width') in the shared object; drop it only if empty.
+          var raw = localStorage.getItem(KEY);
+          var s = raw ? JSON.parse(raw) : {};
+          DIMENSIONS.forEach(function(k) { delete s[k]; });
+          if (Object.keys(s).length) localStorage.setItem(KEY, JSON.stringify(s));
+          else localStorage.removeItem(KEY);
+        } catch (e) {}
         reflect(readCurrent());
       }
 

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -418,7 +418,7 @@ export function contextListPage(
     <div class="card" style="margin-top:2rem;">
       <h3>New Context</h3>
       <div id="new-ctx-error"></div>
-      <form hx-post="/ctx" hx-target="#context-list" hx-swap="beforeend" hx-on::after-request="var slot=document.getElementById('new-ctx-error');if(event.detail.successful){this.reset();slot.innerHTML='';}else{slot.innerHTML=event.detail.xhr.responseText;}">
+      <form hx-post="/ctx" hx-swap="none" hx-on::after-request="var slot=document.getElementById('new-ctx-error');if(event.detail.successful){this.reset();slot.innerHTML='';htmx.ajax('GET',location.pathname+location.search,{target:'#context-list-region',swap:'outerHTML'});}else{slot.innerHTML=event.detail.xhr.responseText;}">
         <label for="name">Name</label>
         <input type="text" id="name" name="name" pattern="[a-zA-Z0-9_-]+" required placeholder="my-project">
         <button type="submit" class="btn btn-primary">Create</button>

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -25,12 +25,23 @@ function statusBadge(status?: string): string {
   return `<span class="status-badge">${esc(status)}</span>`;
 }
 
+const SAFE_LINK_SCHEMES = new Set(["http", "https", "mailto"]);
+
+// Block javascript:/data: and other non-allowlisted schemes — esc() only
+// HTML-escapes, it does not neutralize a dangerous URL scheme in an href.
+function isSafeLinkUrl(url: string): boolean {
+  const match = /^([a-z][a-z0-9+.-]*):/i.exec(url.trim());
+  if (!match) return true; // relative / scheme-less URL
+  return SAFE_LINK_SCHEMES.has(match[1].toLowerCase());
+}
+
 function linksRow(links: ContextMetadata["links"]): string {
   if (!links || links.length === 0) return "";
   const items = links
-    .map(
-      (l) =>
-        `<a class="ctx-link" href="${esc(l.url)}" target="_blank" rel="noopener">${esc(l.label)}</a>`
+    .map((l) =>
+      isSafeLinkUrl(l.url)
+        ? `<a class="ctx-link" href="${esc(l.url)}" target="_blank" rel="noopener">${esc(l.label)}</a>`
+        : `<span class="ctx-link ctx-link-blocked" title="Link blocked: unsupported URL scheme">${esc(l.label)}</span>`
     )
     .join(" ");
   return `<div class="ctx-links">${items}</div>`;
@@ -971,7 +982,15 @@ export function themeLabPage(): string {
         return s;
       }
       function persist(state) {
-        try { localStorage.setItem(KEY, JSON.stringify(state)); } catch (e) {}
+        try {
+          // Read-modify-merge so we preserve sibling keys (e.g. the header's
+          // 'width') that share the same localStorage object — overwriting the
+          // whole object would silently drop the user's width preference.
+          var raw = localStorage.getItem(KEY);
+          var s = raw ? JSON.parse(raw) : {};
+          DIMENSIONS.forEach(function(k) { s[k] = state[k]; });
+          localStorage.setItem(KEY, JSON.stringify(s));
+        } catch (e) {}
       }
       function reflect(state) {
         DIMENSIONS.forEach(function(dim) {

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -120,6 +120,37 @@ export function layout(title: string, body: string): string {
   </div>
   <script>
   (function() {
+    // Surface server error bodies into a shared #flash region. htmx 2.x drops
+    // 4xx/5xx responses by default (swap:false), so without this a rejected
+    // action (e.g. reverting an item whose backup is already gone) gives the
+    // user no visible feedback at all.
+    function flashRegion() {
+      var el = document.getElementById('flash');
+      if (el) return el;
+      el = document.createElement('div');
+      el.id = 'flash';
+      el.setAttribute('aria-live', 'polite');
+      var header = document.querySelector('.container > header');
+      if (header && header.parentNode) header.parentNode.insertBefore(el, header.nextSibling);
+      else document.body.insertBefore(el, document.body.firstChild);
+      return el;
+    }
+    document.body.addEventListener('htmx:beforeSwap', function(evt) {
+      var d = evt.detail;
+      // Forms that render their own inline error opt out via data-flash="off".
+      if (d.elt && d.elt.getAttribute && d.elt.getAttribute('data-flash') === 'off') return;
+      if (d.isError && d.xhr && d.xhr.responseText) {
+        d.shouldSwap = true;
+        d.isError = false;
+        d.target = flashRegion();
+        d.swapOverride = 'innerHTML';
+      } else if (!d.isError) {
+        var prev = document.getElementById('flash');
+        if (prev && d.target !== prev) prev.innerHTML = '';
+      }
+    });
+  })();
+  (function() {
     var c = document.getElementById('noise-canvas');
     if (!c) return;
     var ctx = c.getContext('2d');
@@ -429,7 +460,7 @@ export function contextListPage(
     <div class="card" style="margin-top:2rem;">
       <h3>New Context</h3>
       <div id="new-ctx-error"></div>
-      <form hx-post="/ctx" hx-swap="none" hx-on::after-request="var slot=document.getElementById('new-ctx-error');if(event.detail.successful){this.reset();slot.innerHTML='';htmx.ajax('GET',location.pathname+location.search,{target:'#context-list-region',swap:'outerHTML'});}else{slot.innerHTML=event.detail.xhr.responseText;}">
+      <form hx-post="/ctx" hx-swap="none" data-flash="off" hx-on::after-request="var slot=document.getElementById('new-ctx-error');if(event.detail.successful){this.reset();slot.innerHTML='';htmx.ajax('GET',location.pathname+location.search,{target:'#context-list-region',swap:'outerHTML'});}else{slot.innerHTML=event.detail.xhr.responseText;}">
         <label for="name">Name</label>
         <input type="text" id="name" name="name" pattern="[a-zA-Z0-9_-]+" required placeholder="my-project">
         <button type="submit" class="btn btn-primary">Create</button>

--- a/src/web.ts
+++ b/src/web.ts
@@ -32,7 +32,7 @@ import {
 import { loadConfig, MissingDataDirError, packageVersion } from "./config.js";
 
 const app = express();
-app.use(express.urlencoded({ extended: true }));
+app.use(express.urlencoded({ extended: true, limit: "1mb" }));
 
 // --- Helpers ---
 
@@ -254,6 +254,10 @@ app.post("/ctx/:context/items", async (req, res) => {
       res.status(400).send(`<div class="flash flash-error">Invalid item name.</div>`);
       return;
     }
+    if (typeof extension === "string" && extension.length > 0 && !parseExtQuery(extension)) {
+      res.status(400).send(`<div class="flash flash-error">Invalid item extension.</div>`);
+      return;
+    }
     const ext = parseExtQuery(extension) || "md";
     const tags = parseTags(rawTags);
     await storage.createItem(req.params.context, item, ext, {
@@ -378,13 +382,28 @@ app.post("/ctx/:context/:item/append", async (req, res) => {
   try {
     const { context, item: itemName } = req.params;
     const preferred = parseExtQuery(req.query.ext);
+    const hadBackup = await storage.hasBackup(context, itemName, preferred);
     await storage.appendToItem(context, itemName, req.body.content || "", preferred);
     const item = await storage.getItem(context, itemName, preferred);
     const isMarkdown = item.extension === "md";
     const contentHtml = isMarkdown
       ? await marked.parse(item.content)
       : escHtml(item.content);
-    res.send(contentHtml);
+    // The append form swaps only #doc-body, which sits below the action bar. A
+    // successful append writes a one-shot .bak; if this append created the FIRST
+    // backup, OOB-inject the Revert button into .actions so it surfaces without a
+    // reload (mirrors the markup in itemViewPage). Idempotent: once a backup
+    // exists, hadBackup is true on the next append, so it is not injected twice.
+    let revertOob = "";
+    if (!hadBackup) {
+      const base = `/ctx/${escHtml(context)}/${escHtml(itemName)}`;
+      revertOob =
+        `<button type="button" class="btn btn-sm btn-danger" hx-swap-oob="beforeend:.actions"` +
+        ` hx-post="${base}/revert?ext=${escHtml(item.extension)}"` +
+        ` hx-confirm="Revert '${escHtml(itemName)}.${escHtml(item.extension)}' to previous version? This is one-shot."` +
+        ` title="Restore the previous version. One-shot — cannot be undone.">Revert</button>`;
+    }
+    res.send(contentHtml + revertOob);
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
     res.status(400).send(`<div class="flash flash-error">${escHtml(msg)}</div>`);
@@ -466,6 +485,25 @@ app.post("/shutdown", (_req, res) => {
   );
   setTimeout(() => process.exit(0), 200);
 });
+
+// --- Error handling ---
+
+// Body-parser failures (e.g. PayloadTooLargeError) and any uncaught route error
+// land here. Respond with the app's flash-error convention rather than Express's
+// default stack-trace page, which would otherwise leak absolute server paths.
+app.use(
+  (err: unknown, req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    const tooLarge =
+      typeof err === "object" &&
+      err !== null &&
+      "type" in err &&
+      (err as { type?: string }).type === "entity.too.large";
+    const status = tooLarge ? 413 : 500;
+    const msg = tooLarge ? "Request body too large." : "Something went wrong.";
+    const body = `<div class="flash flash-error">${escHtml(msg)}</div>`;
+    res.status(status).send(req.get("HX-Request") === "true" ? body : layout("Error", body));
+  }
+);
 
 // --- Start ---
 

--- a/src/web.ts
+++ b/src/web.ts
@@ -182,9 +182,12 @@ app.post("/ctx/:context/meta", async (req, res) => {
       if (label && url) links.push({ label, url });
     }
     await storage.updateContextMetadata(req.params.context, {
-      title: body.title?.trim() || undefined,
-      description: body.description?.trim() || undefined,
-      status: body.status?.trim() || undefined,
+      // The form always submits these keys, so an empty value means "clear" —
+      // use ?? "" (a defined empty string storage writes through) rather than
+      // || undefined (which storage treats as "leave unchanged").
+      title: body.title?.trim() ?? "",
+      description: body.description?.trim() ?? "",
+      status: body.status?.trim() ?? "",
       tags: parseTags(body.tags),
       links,
     });
@@ -205,7 +208,7 @@ app.get("/ctx/:context.zip", async (req, res) => {
     await storage.listItems(ctx);
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
-    res.status(404).send(msg);
+    res.status(404).send(escHtml(msg));
     return;
   }
 
@@ -397,11 +400,17 @@ app.post("/ctx/:context/:item/append", async (req, res) => {
     let revertOob = "";
     if (!hadBackup) {
       const base = `/ctx/${escHtml(context)}/${escHtml(itemName)}`;
+      // htmx positional OOB (beforeend:<selector>) swaps the OOB element's
+      // *content* into the target, not the element itself — so the attribute
+      // must sit on a wrapper, or only the bare "Revert" text node lands in
+      // .actions and the button is stripped (inert until reload).
       revertOob =
-        `<button type="button" class="btn btn-sm btn-danger" hx-swap-oob="beforeend:.actions"` +
+        `<div hx-swap-oob="beforeend:.actions">` +
+        `<button type="button" class="btn btn-sm btn-danger"` +
         ` hx-post="${base}/revert?ext=${escHtml(item.extension)}"` +
         ` hx-confirm="Revert '${escHtml(itemName)}.${escHtml(item.extension)}' to previous version? This is one-shot."` +
-        ` title="Restore the previous version. One-shot — cannot be undone.">Revert</button>`;
+        ` title="Restore the previous version. One-shot — cannot be undone.">Revert</button>` +
+        `</div>`;
     }
     res.send(contentHtml + revertOob);
   } catch (err: unknown) {


### PR DESCRIPTION
## What

Two autonomous browser walkthroughs (the `dogfood-loop` workflow): roam each UI area on its own disposable sandbox -> adversarially verify each finding on a fresh sandbox -> author a precise fix spec. Integration (apply, `build` + `sanity` gate, behavioral re-verify) was done in the main loop, which also caught and corrected one of its own fixes (see Notable).

**14 confirmed defects across two runs; all 14 fixed here.** Every fix re-verified against a fresh sandbox (HTTP + real-browser checks).

## Slice 1 — item-crud / list-filtering / search (8 found, 8 fixed)

| Sev | Defect | Fix |
|-----|--------|-----|
| high | `/search?context=..` -> uncaught EISDIR 500 + stack leak + path traversal | `CONTEXT_NAME_REGEX` guard |
| high | New Context server-rejection fails silently (HTMX drops non-2xx) | inject flash-error into `#new-ctx-error` |
| high | Append doesn't surface the Revert control until reload | OOB-inject Revert (corrected in slice-2 commit, see Notable) |
| medium | delete-missing / over-long create leak absolute path | normalized in storage |
| low | oversized body -> Express stack-trace page leaks install path | error handler -> styled flash; 1mb cap |
| low | create silently coerces bad extension to `.md` | 400 reject |
| low | new context appended out of sort order until reload | re-fetch sorted region on success |
| nit | `.yml` missing from create dropdown | added option |

## Wide run — metadata-edit / revert / export-zip / diagnose / theme-lab (6 found, 5 fixed)

| Sev | Defect | Fix |
|-----|--------|-----|
| high | blanking title/description/status can't clear the field | coerce empty to `""` (not undefined) |
| high | append's OOB Revert injected an inert text node, not a button | move `hx-swap-oob` to a wrapper div |
| medium | stored XSS: `javascript:` link rendered as live href | scheme-allowlist (http/https/mailto) |
| medium | reflected XSS: zip 404 reflects context name unescaped | `escHtml` the message |
| medium | theme knob clobbers the header `width` localStorage key | read-modify-merge in `persist()` |
| medium | stale Revert 400 gives no visible feedback | global htmx error-surface routes dropped 4xx/5xx into a shared `#flash` |

## Notable
- **Two XSS issues** fixed (stored `javascript:` link, reflected zip 404) plus a **path-traversal 500** and **three install-path disclosure leaks** — none had prior test coverage.
- The wide run caught that the slice-1 OOB Revert fix **was itself broken** (htmx positional OOB swaps element *content*, so only a bare text node landed). Corrected in the slice-2 commit and browser-verified end to end (the Revert button now appears and actually reverts without a reload).

## Infra
- `scripts/ui-sandbox.js` (disposable UI instance: temp dataDir + free port) and `.gitignore` updates.

## Test
- `build` + `sanity` clean. Re-verify: 19/19 (slice 1) + 7 HTTP + 2 browser (wide run) + 2 browser (stale-Revert error surface), all green.

Generated with [Claude Code](https://claude.com/claude-code)
