### PR TITLE
Add markdown table of contents (left rail)

### DIFF
--- a/scripts/ui-sandbox.js
+++ b/scripts/ui-sandbox.js
@@ -60,7 +60,15 @@ function seed(dataDir) {
   );
   write(
     "alpha-notes/readme.md",
-    ["---", "title: Read Me First", "tags: [intro, guide]", "---", "", "# Alpha", "", "Some **markdown** with a [link](https://example.com).", ""].join("\n"),
+    [
+      "---", "title: Read Me First", "tags: [intro, guide]", "---", "",
+      "# Alpha Notes", "", "Intro paragraph with a [link](https://example.com).", "",
+      "## Getting Started", "", "Some **markdown** body text.", "",
+      "### Installation", "", "Install steps go here.", "",
+      "### Configuration", "", "Config details go here.", "",
+      "## Usage", "", "How to use it.", "",
+      "## Troubleshooting", "", "Problems and fixes.", "",
+    ].join("\n"),
   );
   write("alpha-notes/scratch.txt", "plain text item, no frontmatter, nothing fancy\n");
 

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -791,4 +791,18 @@ export const styles = `
     @keyframes blink-text { 0%, 49% { opacity: 1; } 50%, 100% { opacity: 0.3; } }
     @keyframes stamp-in { 0% { opacity: 0; transform: translateY(-4px); } 100% { opacity: 1; transform: translateY(0); } }
     @keyframes screen-flicker { 0% { opacity: 0.97; } 5% { opacity: 1; } 10% { opacity: 0.98; } 15% { opacity: 1; } 100% { opacity: 1; } }
+
+    /* --- Markdown table of contents (left rail on rendered .md item views) --- */
+    .doc-layout { display: block; }
+    .doc-layout.has-toc { display: grid; grid-template-columns: 13rem minmax(0, 1fr); gap: 2rem; align-items: start; }
+    .doc-toc { position: sticky; top: 1rem; align-self: start; max-height: calc(100vh - 3rem); overflow-y: auto; font-size: 0.82rem; }
+    .doc-toc-title { text-transform: uppercase; letter-spacing: 0.1em; font-size: 0.68rem; color: var(--text-dim); margin-bottom: 0.6rem; }
+    .doc-toc ul { list-style: none; margin: 0; padding: 0; border-left: 1px solid var(--border); }
+    .doc-toc li a { display: block; padding: 0.2rem 0 0.2rem 0.85rem; margin-left: -1px; border-left: 2px solid transparent; color: var(--text-muted); text-decoration: none; line-height: 1.35; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .doc-toc li a:hover { color: var(--text-bright); border-left-color: var(--accent); }
+    .doc-toc .toc-l2 a { padding-left: 1.7rem; }
+    .doc-toc .toc-l3 a { padding-left: 2.55rem; }
+    .doc-toc .toc-l4 a, .doc-toc .toc-l5 a, .doc-toc .toc-l6 a { padding-left: 3.4rem; }
+    .doc-content h1, .doc-content h2, .doc-content h3, .doc-content h4, .doc-content h5, .doc-content h6 { scroll-margin-top: 15rem; }
+    @media (max-width: 60rem) { .doc-layout.has-toc { display: block; } .doc-toc { display: none; } }
   `;

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -47,6 +47,49 @@ function linksRow(links: ContextMetadata["links"]): string {
   return `<div class="ctx-links">${items}</div>`;
 }
 
+export interface TocEntry {
+  level: number;
+  text: string;
+  id: string;
+}
+
+// Inject anchor ids into rendered <h1..h6> tags and pull out a flat table of
+// contents. Operates on marked's HTML output (not the raw markdown) so the TOC
+// ids are guaranteed to match the heading ids the browser actually anchors to.
+export function anchorHeadings(html: string): { html: string; toc: TocEntry[] } {
+  const counts = new Map<string, number>();
+  const toc: TocEntry[] = [];
+  const slug = (text: string): string => {
+    const base =
+      text
+        .toLowerCase()
+        .replace(/&[a-z]+;/g, "")
+        .replace(/[^\w\s-]/g, "")
+        .trim()
+        .replace(/\s+/g, "-")
+        .replace(/-+/g, "-")
+        .replace(/^-+|-+$/g, "") || "section";
+    const n = counts.get(base) ?? 0;
+    counts.set(base, n + 1);
+    return n === 0 ? base : `${base}-${n}`;
+  };
+  const out = html.replace(
+    /<h([1-6])([^>]*)>([\s\S]*?)<\/h\1>/g,
+    (_m, level: string, attrs: string, inner: string) => {
+      const text = inner.replace(/<[^>]+>/g, "").trim();
+      const existing = /\bid="([^"]*)"/.exec(attrs);
+      if (existing) {
+        toc.push({ level: Number(level), text, id: existing[1] });
+        return `<h${level}${attrs}>${inner}</h${level}>`;
+      }
+      const id = slug(text);
+      toc.push({ level: Number(level), text, id });
+      return `<h${level}${attrs} id="${id}">${inner}</h${level}>`;
+    }
+  );
+  return { html: out, toc };
+}
+
 function displayContextTitle(summary: ContextSummary): string {
   const metaTitle = summary.metadata?.title;
   return metaTitle && metaTitle.trim().length > 0 ? metaTitle : summary.name;
@@ -694,6 +737,7 @@ export function itemViewPage(
   isMarkdown: boolean,
   rawMode: boolean = false,
   hasBackup: boolean = false,
+  toc: TocEntry[] = [],
 ): string {
   const appendSupported =
     !rawMode && (isMarkdown || extension === "txt" || extension === "csv" || extension === "sql");
@@ -716,6 +760,18 @@ export function itemViewPage(
   const viewUrl = `/ctx/${esc(context)}/${esc(name)}?ext=${esc(extension)}`;
   const rawToggleHref = rawMode ? viewUrl : `${viewUrl}&raw=1`;
   const rawToggleLabel = rawMode ? "Rendered" : "Raw";
+
+  // Left-rail table of contents, deduced from the rendered markdown headings.
+  // Only shown for rendered markdown with more than one heading.
+  const tocHtml =
+    isMarkdown && !rawMode && toc.length > 1
+      ? `<nav class="doc-toc" aria-label="Table of contents">
+        <div class="doc-toc-title">On this page</div>
+        <ul>${toc
+          .map((t) => `<li class="toc-l${t.level}"><a href="#${esc(t.id)}">${t.text}</a></li>`)
+          .join("")}</ul>
+      </nav>`
+      : "";
 
   return layout(
     title,
@@ -741,7 +797,10 @@ export function itemViewPage(
         ${hasBackup ? `<button type="button" class="btn btn-sm btn-danger" hx-post="/ctx/${esc(context)}/${esc(name)}/revert?ext=${esc(extension)}" hx-confirm="Revert '${esc(name)}.${esc(extension)}' to previous version? This is one-shot." title="Restore the previous version. One-shot — cannot be undone.">Revert</button>` : ""}
       </div>
     </div>
-    <div class="${contentClass}" id="doc-body">${contentHtml}</div>
+    <div class="doc-layout${tocHtml ? " has-toc" : ""}">
+      ${tocHtml}
+      <div class="${contentClass}" id="doc-body">${contentHtml}</div>
+    </div>
     ${appendForm}`
   );
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -28,6 +28,8 @@ import {
   itemEditPage,
   searchPage,
   themeLabPage,
+  anchorHeadings,
+  TocEntry,
 } from "./templates.js";
 import { loadConfig, MissingDataDirError, packageVersion } from "./config.js";
 
@@ -305,12 +307,15 @@ app.get("/ctx/:context/:item", async (req, res) => {
     const item = await storage.getItem(context, itemName, preferred);
     const isMarkdown = item.extension === "md";
     let contentHtml: string;
+    let toc: TocEntry[] = [];
     if (rawMode) {
       // Always show the verbatim file content in raw mode (md includes frontmatter).
       const rawItem = await storage.getItemRaw(context, itemName, preferred);
       contentHtml = escHtml(rawItem.content);
     } else if (isMarkdown) {
-      contentHtml = await marked.parse(item.content);
+      const anchored = anchorHeadings(await marked.parse(item.content));
+      contentHtml = anchored.html;
+      toc = anchored.toc;
     } else {
       contentHtml = escHtml(item.content);
     }
@@ -329,6 +334,7 @@ app.get("/ctx/:context/:item", async (req, res) => {
         isMarkdown,
         rawMode,
         hasBackup,
+        toc,
       )
     );
   } catch (err: unknown) {


### PR DESCRIPTION
## What

Feature 1 of 3 from the latest batch: a **table of contents** for rendered markdown items.

Rendered markdown item views now show a sticky left-hand TOC deduced from the document's headings, with level-based indentation. Clicking an entry jumps to that heading.

## How

- `anchorHeadings(html)` (templates.ts) runs once over marked's rendered HTML: it injects slugged anchor ids into each `<h1..h6>` and extracts a flat TOC in the same pass — so the TOC's `#ids` are guaranteed to match the heading anchors the browser navigates to (no separate slugging that could drift). Duplicate heading texts get `-1`, `-2` suffixes.
- `itemViewPage` renders the TOC as `nav.doc-toc` in a 2-column `.doc-layout` grid (rail left, content right).
- Shown **only** for rendered markdown with more than one heading — never for raw mode or non-markdown items.
- Headings get `scroll-margin-top` so anchor jumps clear the stacked sticky header (page header + breadcrumb + item-title bar) instead of landing behind it.
- The `ui-sandbox` readme fixture is enriched with a multi-heading doc so the feature works out of the box.

## Test

- `build` clean.
- HTTP: 9/9 structural checks (TOC nav, anchor links, matching heading ids, nesting classes, correctly excluded for raw mode + non-markdown items).
- Browser: TOC renders on the left with correct nesting; clicking "Troubleshooting" anchor-scrolls the heading fully into view (top 240px, not occluded by the sticky stack).

Generated with [Claude Code](https://claude.com/claude-code)
