### PR TITLE
Add file attachments (assets/) with markdown embedding

### DIFF
--- a/scripts/sanity.js
+++ b/scripts/sanity.js
@@ -130,6 +130,35 @@ async function run() {
     assertEq(raw.contentType, "application/sql; charset=utf-8", "mime");
   });
 
+  await check("attachments: add/list/dedup, traversal-guard, not-an-item, delete", async () => {
+    await storage.createContext("eviden");
+    const srcPng = path.join(tmpRoot, "src-shot.png");
+    fs.writeFileSync(srcPng, Buffer.from("89504e470d0a1a0a0000", "hex"));
+    const info = await storage.addAttachment("eviden", srcPng, "shot");
+    assertEq(info.filename, "shot.png", "attachment filename");
+    if (info.size <= 0) throw new Error("attachment size should be > 0");
+    assertEq((await storage.listAttachments("eviden")).map((a) => a.filename), ["shot.png"], "list after add");
+    // same name dedups rather than clobbering
+    const info2 = await storage.addAttachment("eviden", srcPng, "shot");
+    assertEq(info2.filename, "shot-1.png", "dedup filename");
+    // unsupported extension rejected
+    const srcExe = path.join(tmpRoot, "evil.exe");
+    fs.writeFileSync(srcExe, "x");
+    let rejectedExt = false;
+    try { await storage.addAttachment("eviden", srcExe); } catch { rejectedExt = true; }
+    if (!rejectedExt) throw new Error("unsupported extension should be rejected");
+    // path traversal rejected at the resolve boundary
+    let rejectedTraversal = false;
+    try { storage.attachmentFilePath("eviden", "../../secret.png"); } catch { rejectedTraversal = true; }
+    if (!rejectedTraversal) throw new Error("traversal filename should be rejected");
+    // assets dir must NOT surface as an item
+    if ((await storage.listItems("eviden")).some((i) => i.name === "assets")) {
+      throw new Error("assets dir leaked into items");
+    }
+    await storage.deleteAttachment("eviden", "shot.png");
+    assertEq((await storage.listAttachments("eviden")).map((a) => a.filename), ["shot-1.png"], "list after delete");
+  });
+
   console.log("");
   if (failed > 0) {
     console.error(`${failed} check(s) failed`);

--- a/scripts/ui-sandbox.js
+++ b/scripts/ui-sandbox.js
@@ -76,6 +76,26 @@ function seed(dataDir) {
   // A search target with a distinctive token, for exercising full-text search.
   write("query-target/_context.yaml", ["title: Query Target", "status: active", "tags: [search]", ""].join("\n"));
   write("query-target/findme.md", ["---", "title: Find Me", "---", "", "The magic token is ZEBRAFISH and it appears exactly once.", ""].join("\n"));
+
+  // Binary attachments in alpha-notes/assets, plus a markdown report embedding
+  // them — exercises the assets serve route and the markdown media-embed.
+  const assets = path.join(dataDir, "alpha-notes", "assets");
+  fs.mkdirSync(assets, { recursive: true });
+  // a real 1x1 transparent PNG
+  fs.writeFileSync(
+    path.join(assets, "pixel.png"),
+    Buffer.from("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==", "base64"),
+  );
+  // a webm placeholder (just the EBML signature — enough to serve + embed)
+  fs.writeFileSync(path.join(assets, "demo.webm"), Buffer.from("1a45dfa3", "hex"));
+  write(
+    "alpha-notes/evidence.md",
+    [
+      "---", "title: Evidence Report", "tags: [evidence]", "---", "",
+      "# Evidence", "", "A screenshot from the run:", "", "![pixel](assets/pixel.png)", "",
+      "A recording of the flow:", "", "![demo](assets/demo.webm)", "",
+    ].join("\n"),
+  );
 }
 
 async function main() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,9 @@ import {
   SearchContextsArgsSchema,
   ContextDiagnoseArgsSchema,
   GetGuideArgsSchema,
+  AddAttachmentArgsSchema,
+  ListAttachmentsArgsSchema,
+  DeleteAttachmentArgsSchema,
 } from "./types.js";
 import * as storage from "./storage.js";
 import { searchContexts } from "./search.js";
@@ -349,6 +352,49 @@ server.registerTool(
   async (args) => {
     await storage.appendToItem(args.context, args.item, args.content, args.extension);
     return text(`Content appended to '${args.item}'.`);
+  }
+);
+
+server.registerTool(
+  "add_attachment",
+  {
+    description:
+      "Copy a local file (image/video/audio/pdf) into a context's assets/ folder as an attachment, then reference it from markdown with ![alt](assets/<filename>). Ideal for an agent saving screenshots, webm recordings, or reports into a durable context.",
+    inputSchema: AddAttachmentArgsSchema.shape,
+  },
+  async (args) => {
+    const info = await storage.addAttachment(args.context, args.source_path, args.name);
+    return text(
+      `Attachment '${info.filename}' added to '${args.context}' (${info.size} bytes).\n` +
+        `Embed in a markdown item: ![${info.filename}](assets/${info.filename})`
+    );
+  }
+);
+
+server.registerTool(
+  "list_attachments",
+  {
+    description: "List the attachments stored in a context's assets/ folder.",
+    inputSchema: ListAttachmentsArgsSchema.shape,
+  },
+  async (args) => {
+    const list = await storage.listAttachments(args.context);
+    if (!list.length) return text(`No attachments in '${args.context}'.`);
+    return text(
+      list.map((a) => `${a.filename}  (${a.size} bytes, updated ${a.updated})`).join("\n")
+    );
+  }
+);
+
+server.registerTool(
+  "delete_attachment",
+  {
+    description: "Delete an attachment from a context's assets/ folder. Destructive.",
+    inputSchema: DeleteAttachmentArgsSchema.shape,
+  },
+  async (args) => {
+    await storage.deleteAttachment(args.context, args.filename);
+    return text(`Attachment '${args.filename}' deleted from '${args.context}'.`);
   }
 );
 

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -4,6 +4,11 @@ import matter from "gray-matter";
 import yaml from "js-yaml";
 import { loadConfig, packageVersion } from "./config.js";
 import {
+  ATTACHMENT_EXTENSIONS,
+  ATTACHMENT_NAME_REGEX,
+  ATTACHMENTS_DIRNAME,
+  AttachmentExtension,
+  AttachmentInfo,
   CONTEXT_META_FILENAME,
   CONTEXT_NAME_REGEX,
   ContextLink,
@@ -417,6 +422,137 @@ export async function deleteContext(name: string): Promise<void> {
     throw new Error(`Context '${name}' not found`);
   });
   await fs.rm(dir, { recursive: true, force: true });
+}
+
+// --- Attachments ---
+// Binary evidence (images/video/audio/pdf) stored in a context's assets/
+// subfolder. Never exposed as an item — listItems skips it (not a whitelisted
+// item file) — and served as static files via the web UI.
+
+function attachmentExtOf(filename: string): AttachmentExtension | null {
+  const dot = filename.lastIndexOf(".");
+  if (dot <= 0) return null;
+  const ext = filename.slice(dot + 1).toLowerCase();
+  return (ATTACHMENT_EXTENSIONS as readonly string[]).includes(ext)
+    ? (ext as AttachmentExtension)
+    : null;
+}
+
+function resolveAttachmentsDir(context: string): string {
+  const contextDir = resolveContextPath(context);
+  const resolved = path.resolve(contextDir, ATTACHMENTS_DIRNAME);
+  assertWithin(contextDir, resolved, "attachments dir");
+  return resolved;
+}
+
+// Resolve + validate a single attachment path. Defense in depth: the filename
+// must pass the name regex and carry a whitelisted extension, and the resolved
+// path must stay inside the context's assets/ dir.
+export function attachmentFilePath(context: string, filename: string): string {
+  if (!ATTACHMENT_NAME_REGEX.test(filename) || !attachmentExtOf(filename)) {
+    throw new Error(`Invalid attachment filename '${filename}'`);
+  }
+  const dir = resolveAttachmentsDir(context);
+  const resolved = path.resolve(dir, filename);
+  assertWithin(dir, resolved, "attachment filename");
+  return resolved;
+}
+
+export async function addAttachment(
+  context: string,
+  sourcePath: string,
+  name?: string
+): Promise<AttachmentInfo> {
+  await fs.access(resolveContextPath(context)).catch(() => {
+    throw new Error(`Context '${context}' not found`);
+  });
+
+  const srcExt = path.extname(sourcePath).slice(1).toLowerCase();
+  if (!(ATTACHMENT_EXTENSIONS as readonly string[]).includes(srcExt)) {
+    throw new Error(
+      `Unsupported attachment type '.${srcExt}'. Allowed: ${ATTACHMENT_EXTENSIONS.join(", ")}`
+    );
+  }
+
+  let bytes: Buffer;
+  try {
+    bytes = await fs.readFile(sourcePath);
+  } catch {
+    throw new Error(`Source file not found or unreadable: ${sourcePath}`);
+  }
+
+  const rawBase =
+    (name && name.trim()) || path.basename(sourcePath, path.extname(sourcePath));
+  const base =
+    rawBase
+      .replace(/[^a-zA-Z0-9._-]/g, "-")
+      .replace(/^[._-]+/, "")
+      .replace(/-+/g, "-") || "attachment";
+
+  const dir = resolveAttachmentsDir(context);
+  await fs.mkdir(dir, { recursive: true });
+
+  // Pick a non-colliding filename: base.ext, base-1.ext, base-2.ext, ...
+  let filename = `${base}.${srcExt}`;
+  for (let n = 1; ; n++) {
+    try {
+      await fs.access(path.join(dir, filename));
+      filename = `${base}-${n}.${srcExt}`;
+    } catch {
+      break;
+    }
+  }
+
+  const dest = attachmentFilePath(context, filename);
+  await fs.writeFile(dest, bytes);
+  await touchContext(context);
+
+  const stat = await fs.stat(dest);
+  return {
+    filename,
+    extension: srcExt as AttachmentExtension,
+    size: stat.size,
+    created: statCreatedISO(stat),
+    updated: stat.mtime.toISOString(),
+  };
+}
+
+export async function listAttachments(context: string): Promise<AttachmentInfo[]> {
+  await fs.access(resolveContextPath(context)).catch(() => {
+    throw new Error(`Context '${context}' not found`);
+  });
+  const dir = resolveAttachmentsDir(context);
+  let entries: string[];
+  try {
+    entries = await fs.readdir(dir);
+  } catch {
+    return [];
+  }
+  const out: AttachmentInfo[] = [];
+  for (const entry of entries) {
+    const ext = attachmentExtOf(entry);
+    if (!ext || !ATTACHMENT_NAME_REGEX.test(entry)) continue;
+    const stat = await fs.stat(path.join(dir, entry));
+    if (!stat.isFile()) continue;
+    out.push({
+      filename: entry,
+      extension: ext,
+      size: stat.size,
+      created: statCreatedISO(stat),
+      updated: stat.mtime.toISOString(),
+    });
+  }
+  out.sort((a, b) => a.filename.localeCompare(b.filename));
+  return out;
+}
+
+export async function deleteAttachment(context: string, filename: string): Promise<void> {
+  const p = attachmentFilePath(context, filename);
+  await fs.access(p).catch(() => {
+    throw new Error(`Attachment '${filename}' not found in context '${context}'`);
+  });
+  await fs.rm(p, { force: true });
+  await touchContext(context);
 }
 
 // --- Item operations ---

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -791,4 +791,11 @@ export const styles = `
     @keyframes blink-text { 0%, 49% { opacity: 1; } 50%, 100% { opacity: 0.3; } }
     @keyframes stamp-in { 0% { opacity: 0; transform: translateY(-4px); } 100% { opacity: 1; transform: translateY(0); } }
     @keyframes screen-flicker { 0% { opacity: 0.97; } 5% { opacity: 1; } 10% { opacity: 0.98; } 15% { opacity: 1; } 100% { opacity: 1; } }
+
+    /* --- Embedded markdown media (attachments from assets/) --- */
+    .doc-content img { max-width: 100%; height: auto; border-radius: 4px; }
+    .doc-content video.doc-media { display: block; max-width: 100%; margin: 1rem 0; border-radius: 4px; background: #000; }
+    .doc-content audio.doc-media { display: block; width: 100%; margin: 1rem 0; }
+    .doc-content a.doc-attachment { display: inline-block; padding: 0.3rem 0.7rem; margin: 0.25rem 0; border: 1px solid var(--border); border-radius: 4px; color: var(--accent); text-decoration: none; }
+    .doc-content a.doc-attachment:hover { border-color: var(--accent-line-hover); }
   `;

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,24 @@ export const CONTEXT_NAME_REGEX = /^[a-zA-Z0-9_-]+$/;
 // names like "_context".
 export const ITEM_NAME_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9_-]*$/;
 
+// --- Attachments ---
+// Binary evidence (images/video/audio/pdf) lives in a context's assets/ subfolder,
+// referenced from markdown via ![alt](assets/<filename>). Deliberately excludes
+// active/executable types (no svg, html, js) — these are served as static files.
+export const ATTACHMENT_EXTENSIONS = [
+  "png", "jpg", "jpeg", "gif", "webp", "avif",
+  "mp4", "webm", "mov", "ogg",
+  "mp3", "wav",
+  "pdf",
+] as const;
+export type AttachmentExtension = (typeof ATTACHMENT_EXTENSIONS)[number];
+
+export const ATTACHMENTS_DIRNAME = "assets";
+
+// Attachment file names (with extension): start alphanumeric, then word chars,
+// dot, hyphen. Validated at the storage boundary and on every serve.
+export const ATTACHMENT_NAME_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
+
 // --- Context metadata ---
 
 export interface ContextLink {
@@ -59,6 +77,14 @@ export interface ItemInfo {
   created: string;     // md: frontmatter; non-md: fs.stat birthtime/ctime
   updated: string;     // md: frontmatter; non-md: fs.stat mtime
   size: number;
+}
+
+export interface AttachmentInfo {
+  filename: string; // includes extension, e.g. screenshot-1.png
+  extension: AttachmentExtension;
+  size: number;
+  created: string;
+  updated: string;
 }
 
 // Full read result.
@@ -227,4 +253,24 @@ export const ContextDiagnoseArgsSchema = z.object({});
 const GUIDE_NAMES = ["migration", "mermaid"] as const;
 export const GetGuideArgsSchema = z.object({
   name: z.enum(GUIDE_NAMES),
+});
+
+export const AddAttachmentArgsSchema = z.object({
+  context: z.string(),
+  source_path: z
+    .string()
+    .describe("Path to a local file to copy in (e.g. a Playwright screenshot or webm)."),
+  name: z
+    .string()
+    .optional()
+    .describe("Optional base name (without extension) for the stored file; defaults to the source file's name."),
+});
+
+export const ListAttachmentsArgsSchema = z.object({
+  context: z.string(),
+});
+
+export const DeleteAttachmentArgsSchema = z.object({
+  context: z.string(),
+  filename: z.string().describe("Attachment filename including extension, e.g. screenshot-1.png."),
 });

--- a/src/web.ts
+++ b/src/web.ts
@@ -91,6 +91,35 @@ function parseTags(raw: unknown): string[] {
     .filter(Boolean);
 }
 
+// Rewrite markdown <img> tags that point at non-image attachments into the
+// right element: video/audio get native players, PDFs a link. Image references
+// (png/jpg/...) are left as <img> and resolve to the assets route. src/alt come
+// from marked's already-escaped output, so re-emitting them is safe.
+function embedMediaTags(html: string): string {
+  const videoExt = /\.(mp4|webm|mov|ogg)(?:[?#].*)?$/i;
+  const audioExt = /\.(mp3|wav)(?:[?#].*)?$/i;
+  const pdfExt = /\.pdf(?:[?#].*)?$/i;
+  return html.replace(/<img\b[^>]*>/g, (tag) => {
+    const srcM = /\bsrc="([^"]*)"/.exec(tag);
+    if (!srcM) return tag;
+    const src = srcM[1];
+    const altM = /\balt="([^"]*)"/.exec(tag);
+    const alt = altM ? altM[1] : "";
+    const aria = alt ? ` aria-label="${alt}"` : "";
+    if (videoExt.test(src)) {
+      return `<video src="${src}" controls preload="metadata" class="doc-media"${aria}></video>`;
+    }
+    if (audioExt.test(src)) {
+      return `<audio src="${src}" controls preload="metadata" class="doc-media"${aria}></audio>`;
+    }
+    if (pdfExt.test(src)) {
+      const label = alt || src.split("/").pop() || "PDF";
+      return `<a class="doc-attachment" href="${src}" target="_blank" rel="noopener">${label}</a>`;
+    }
+    return tag;
+  });
+}
+
 // --- Context routes ---
 
 app.get("/", async (req, res) => {
@@ -297,6 +326,20 @@ app.get("/ctx/:context/:item/raw", async (req, res) => {
   }
 });
 
+// --- Attachment serving (static binary files from a context's assets/ folder) ---
+app.get("/ctx/:context/assets/:filename", (req, res) => {
+  let filePath: string;
+  try {
+    filePath = storage.attachmentFilePath(req.params.context, req.params.filename);
+  } catch (err: unknown) {
+    res.status(404).send(escHtml(err instanceof Error ? err.message : String(err)));
+    return;
+  }
+  res.sendFile(filePath, (err) => {
+    if (err && !res.headersSent) res.status(404).send("Attachment not found");
+  });
+});
+
 app.get("/ctx/:context/:item", async (req, res) => {
   try {
     const { context, item: itemName } = req.params;
@@ -310,7 +353,7 @@ app.get("/ctx/:context/:item", async (req, res) => {
       const rawItem = await storage.getItemRaw(context, itemName, preferred);
       contentHtml = escHtml(rawItem.content);
     } else if (isMarkdown) {
-      contentHtml = await marked.parse(item.content);
+      contentHtml = embedMediaTags(await marked.parse(item.content));
     } else {
       contentHtml = escHtml(item.content);
     }


### PR DESCRIPTION
## What

Feature 3 of 3 — the keystone. Contexts can now hold **binary attachments** (screenshots, webm/mp4 recordings, audio, PDFs), and markdown items can **embed them inline**. A testing agent can drop Playwright evidence into a context and grow a single, self-contained evidence report.

Design (per the chosen options): attachments live in a per-context **`assets/`** subfolder, and an agent adds them by **copying a local file path** (no base64 bloat).

## How

**Storage** (`storage.ts`)
- `addAttachment(context, source_path, name?)` copies a local file into `<context>/assets/`, dedups name collisions (`shot.png` → `shot-1.png`), and returns its info.
- `listAttachments`, `deleteAttachment`, and `attachmentFilePath` all go through the same path-safety guard as items: name regex + extension allowlist + `assertWithin` (no traversal). Active types (svg/html/js) are deliberately excluded.
- The `assets/` dir is never surfaced as an item.

**MCP** (`index.ts`)
- `add_attachment`, `list_attachments`, `delete_attachment`. `add_attachment` returns the ready-to-paste markdown snippet `![name](assets/name.ext)`.

**Web** (`web.ts`)
- `GET /ctx/:context/assets/:filename` serves the file (content-type by extension, path-safe).
- Rendered markdown rewrites `<img>` refs that point at video/webm → `<video controls>`, audio → `<audio>`, pdf → a link. Image refs resolve to the assets route for free (relative URL).

## Use case

```
agent: add_attachment({ context: 'login-bug', source_path: 'C:/tmp/shot.png' })
  -> "Embed in a markdown item: ![shot.png](assets/shot.png)"
agent: append_to_item({ context: 'login-bug', item: 'report',
        content: '## Step 3 failed\n\n![shot.png](assets/shot.png)' })
```
The human opens `report.md` and sees the screenshot inline.

## Test

- `build` clean.
- `sanity`: 8/8 incl. a new attachments check (add/list/dedup, traversal-guard, assets-not-an-item, delete).
- HTTP: 9/9 — serve content-type (png/webm), markdown img/video embed, traversal + missing + non-whitelisted-extension all 404.
- `ui-sandbox` now seeds an `assets/` png + webm and an `evidence.md` embedding them, so the feature works out of the box.

Note: branches off `master` independently of the TOC PR (#6); both touch the item render pipeline in one small spot, so expect a trivial merge resolution if both land.

Generated with [Claude Code](https://claude.com/claude-code)
