### PR TITLE
Fix TOC rail: wrap long headings + anchor in the left window gutter

### DIFF
--- a/scripts/ui-sandbox.js
+++ b/scripts/ui-sandbox.js
@@ -58,16 +58,22 @@ function seed(dataDir) {
       "",
     ].join("\n"),
   );
+  // Long, multi-word headings + filler body so the TOC rail is genuinely
+  // exercised (wrapping long entries) and the page is tall enough to scroll
+  // (testing sticky behaviour past the sticky header chrome).
+  const para =
+    "Filler body text to make the document tall enough that the sticky table-of-contents rail has something to scroll past, and long enough that headings exercise the wrapping in the rail.";
   write(
     "alpha-notes/readme.md",
     [
       "---", "title: Read Me First", "tags: [intro, guide]", "---", "",
-      "# Alpha Notes", "", "Intro paragraph with a [link](https://example.com).", "",
-      "## Getting Started", "", "Some **markdown** body text.", "",
-      "### Installation", "", "Install steps go here.", "",
-      "### Configuration", "", "Config details go here.", "",
-      "## Usage", "", "How to use it.", "",
-      "## Troubleshooting", "", "Problems and fixes.", "",
+      "# The Problem With Long-Lived Project Context", "", para, "", para, "",
+      "## A Filing Cabinet For Your Agent's Working Memory", "", para, "", para, "",
+      "### Optional Metadata And Why It Matters Here", "", para, "", para, "",
+      "### Configuration Knobs You Will Probably Never Touch", "", para, "", para, "",
+      "## The Tools And How They Compose Together", "", para, "", para, "",
+      "## Setup, Configuration, And A First Run", "", para, "", para, "",
+      "## Composability With Other MCP Servers", "", para, "", para, "",
     ].join("\n"),
   );
   write("alpha-notes/scratch.txt", "plain text item, no frontmatter, nothing fancy\n");

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -794,16 +794,18 @@ export const styles = `
 
     /* --- Markdown table of contents (left rail on rendered .md item views) --- */
     .doc-layout { display: block; }
-    .doc-layout.has-toc { display: grid; grid-template-columns: 14rem minmax(0, 1fr); gap: 2.5rem; align-items: start; }
-    /* Stick BELOW the full-width sticky chrome (header + breadcrumb + item-title
-       bar, ~13rem) so the rail isn't hidden behind it while scrolling. */
+    /* The table of contents lives in the left WINDOW gutter — fixed, OUTSIDE the
+       centered content column — so it never eats content width and is never
+       clipped by the in-container sticky chrome (header/breadcrumb/title bar).
+       Hidden when the gutter is too small (narrow window or wide content mode). */
     .doc-toc {
-      position: sticky;
-      top: calc(var(--sticky-header-h) + var(--sticky-crumb-h) + 6.5rem);
-      align-self: start;
-      max-height: calc(100vh - var(--sticky-header-h) - var(--sticky-crumb-h) - 8rem);
-      overflow-y: auto; font-size: 0.8rem;
+      position: fixed; top: 6rem; left: 1.5rem; width: 13rem; z-index: 5;
+      max-height: calc(100vh - 8rem); overflow-y: auto; font-size: 0.8rem;
     }
+    @media (max-width: 1320px) { .doc-toc { display: none; } }
+    :root[data-width="medium"] .doc-toc { display: none; }
+    @media (min-width: 1640px) { :root[data-width="medium"] .doc-toc { display: block; } }
+    :root[data-width="wide"] .doc-toc { display: none; }
     .doc-toc-title { text-transform: uppercase; letter-spacing: 0.1em; font-size: 0.68rem; color: var(--text-dim); margin: 0 0 0.5rem 0.85rem; }
     .doc-toc ul { list-style: none; margin: 0; padding: 0; border-left: 1px solid var(--border); }
     .doc-toc li a { display: block; padding: 0.25rem 0.6rem 0.25rem 0.85rem; margin-left: -1px; border-left: 2px solid transparent; color: var(--text-muted); text-decoration: none; line-height: 1.3; overflow-wrap: anywhere; }
@@ -812,7 +814,6 @@ export const styles = `
     .doc-toc .toc-l3 a { padding-left: 2.15rem; }
     .doc-toc .toc-l4 a, .doc-toc .toc-l5 a, .doc-toc .toc-l6 a { padding-left: 2.8rem; }
     .doc-content h1, .doc-content h2, .doc-content h3, .doc-content h4, .doc-content h5, .doc-content h6 { scroll-margin-top: 15rem; }
-    @media (max-width: 60rem) { .doc-layout.has-toc { display: block; } .doc-toc { display: none; } }
 
     /* --- Embedded markdown media (attachments from assets/) --- */
     .doc-content img { max-width: 100%; height: auto; border-radius: 4px; }

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -794,15 +794,23 @@ export const styles = `
 
     /* --- Markdown table of contents (left rail on rendered .md item views) --- */
     .doc-layout { display: block; }
-    .doc-layout.has-toc { display: grid; grid-template-columns: 13rem minmax(0, 1fr); gap: 2rem; align-items: start; }
-    .doc-toc { position: sticky; top: 1rem; align-self: start; max-height: calc(100vh - 3rem); overflow-y: auto; font-size: 0.82rem; }
-    .doc-toc-title { text-transform: uppercase; letter-spacing: 0.1em; font-size: 0.68rem; color: var(--text-dim); margin-bottom: 0.6rem; }
+    .doc-layout.has-toc { display: grid; grid-template-columns: 14rem minmax(0, 1fr); gap: 2.5rem; align-items: start; }
+    /* Stick BELOW the full-width sticky chrome (header + breadcrumb + item-title
+       bar, ~13rem) so the rail isn't hidden behind it while scrolling. */
+    .doc-toc {
+      position: sticky;
+      top: calc(var(--sticky-header-h) + var(--sticky-crumb-h) + 6.5rem);
+      align-self: start;
+      max-height: calc(100vh - var(--sticky-header-h) - var(--sticky-crumb-h) - 8rem);
+      overflow-y: auto; font-size: 0.8rem;
+    }
+    .doc-toc-title { text-transform: uppercase; letter-spacing: 0.1em; font-size: 0.68rem; color: var(--text-dim); margin: 0 0 0.5rem 0.85rem; }
     .doc-toc ul { list-style: none; margin: 0; padding: 0; border-left: 1px solid var(--border); }
-    .doc-toc li a { display: block; padding: 0.2rem 0 0.2rem 0.85rem; margin-left: -1px; border-left: 2px solid transparent; color: var(--text-muted); text-decoration: none; line-height: 1.35; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .doc-toc li a { display: block; padding: 0.25rem 0.6rem 0.25rem 0.85rem; margin-left: -1px; border-left: 2px solid transparent; color: var(--text-muted); text-decoration: none; line-height: 1.3; overflow-wrap: anywhere; }
     .doc-toc li a:hover { color: var(--text-bright); border-left-color: var(--accent); }
-    .doc-toc .toc-l2 a { padding-left: 1.7rem; }
-    .doc-toc .toc-l3 a { padding-left: 2.55rem; }
-    .doc-toc .toc-l4 a, .doc-toc .toc-l5 a, .doc-toc .toc-l6 a { padding-left: 3.4rem; }
+    .doc-toc .toc-l2 a { padding-left: 1.5rem; }
+    .doc-toc .toc-l3 a { padding-left: 2.15rem; }
+    .doc-toc .toc-l4 a, .doc-toc .toc-l5 a, .doc-toc .toc-l6 a { padding-left: 2.8rem; }
     .doc-content h1, .doc-content h2, .doc-content h3, .doc-content h4, .doc-content h5, .doc-content h6 { scroll-margin-top: 15rem; }
     @media (max-width: 60rem) { .doc-layout.has-toc { display: block; } .doc-toc { display: none; } }
 


### PR DESCRIPTION
Fixes the TOC rail, which looked broken on real content. Two rounds:

1. **Wrapping** — entries used `white-space: nowrap`, so long headings were truncated. Now `overflow-wrap: anywhere` wraps them to full multi-line entries.
2. **Placement** — the rail lived *inside* the centered content column, where it was clipped by the in-container sticky chrome (header + breadcrumb + title bar) and ate content width. It's now `position: fixed` in the **left window gutter, outside the content column**, so it's never clipped and the content keeps its full width. It stays put while scrolling and hides when there's no gutter (narrow window or wide content mode).

Why the gutter works: all the sticky chrome lives inside the centered `.container`, so anything inside it can't escape. Moving the TOC outside sidesteps the whole problem. Safe because no ancestor has a `transform`/`filter` (which would break `position: fixed`).

Also: the `ui-sandbox` `readme` fixture now uses **long multi-word headings + filler body**, so this case is actually exercised — the original short-heading fixture hid the bugs (and my first browser check with it).

**Browser-verified** at 1500×900: rail sits at left 24px, clear of the content column (104px gap, no overlap), first entry fully visible (top 96, not chopped); `navTop` unchanged after scrolling 1400px (genuinely fixed); correctly hidden at 1180px.

Generated with [Claude Code](https://claude.com/claude-code)
